### PR TITLE
Define documentation guidelines (#3)

### DIFF
--- a/docs/backlog/ideas.md
+++ b/docs/backlog/ideas.md
@@ -22,14 +22,15 @@ for later review: durable, not opionated, no overlap (segmented).
 tagging for indexing
 headers matching file names mathcing meta data names?
 
-
+Keep up with ai and techs!! Dont let the project fall behind. Ai ide + workflow. Ai assisted development. 
+Restaurant gpt in papp, aicompatability based on restaurant data. Link beli and resy and other stuff to find commonalities. Part of algo. 
 
 
 to do before system design:
-the two adrs and adr template.
-docs/README.md
-docs/standards/decision-making.md
+DONE: the two adrs and adr template.
+DONE: docs/README.md
 docs/standards/documentation-guidelines.md
+docs/standards/decision-making.md
 docs/standards/documentation-maintenance.md
 docs/standards/ownership-and-responsibility.md
 docs/standards/work-lifecycle.md

--- a/docs/standards/documentation-guidelines.md
+++ b/docs/standards/documentation-guidelines.md
@@ -1,7 +1,7 @@
 ---
 title: Documentation Guidelines
 doc_type: standard
-status: draft
+status: accepted
 owners: ["@julian-cardone"]
 tags: [documentation, standards]
 ---
@@ -118,13 +118,14 @@ _Why it Exists_
 - All documents must include a metadata header.
 - Required fields must not be omitted.
 - Optional fields should only be included when meaningful.
-- Metadata should be updated only when the document meaning changes.
+- Metadata should be updated only when the semantic meaning or authority of the document changes.
 
 ## Creating vs Updating Documentation
 
 - Update an existing document when the change refines or extends the same concept.
 - Create a new document when the change introduces a new concept, decision, or responsibility.
 - Avoid duplicating information across multiple documents.
+- When in doubt, prefer updating an existing document and linking to related material rather than creating near-duplicates.
 
 ## Documentation Tone
 


### PR DESCRIPTION
Closes #3 

## Summary
- Defines documentation standards and metadata requirements.
- Establishes document lifecycle rules (draft, accepted, deprecated, superseded).
- Clarifies ownership, authority, and deletion expectations across doc types.

## Notes for Review
- Metadata headers are now required for all documentation.
- ADRs are explicitly immutable (deprecated/superseded only).
- Guidelines are written to be machine-readable for future automation.