### PR TITLE
chore(ci): skip checks for Dependabot PRs using guard job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  guard:
+    name: Guard
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - run: echo "Not a Dependabot PR"
+
   lint-markdown:
     name: Lint Markdown
+    needs: guard
     uses: ./.github/workflows/lint-markdown.yml
 
   doc-checks:
     name: Documentation checks
+    needs: guard
     uses: ./.github/workflows/doc-checks.yml
 
   pr-title:
     name: PR title validation
+    needs: guard
     uses: ./.github/workflows/pr-title.yml

--- a/docs/process/ci-pipeline.md
+++ b/docs/process/ci-pipeline.md
@@ -28,9 +28,10 @@ contributor's responsibility, but CI is the final authority.
 
 ### `ci.yml`
 
-The primary CI workflow. Runs on all pull requests targeting `main`. Calls `lint-markdown.yml`,
-`doc-checks.yml`, and `pr-title.yml` as reusable workflows. Cancels in-progress runs for the same
-branch when a new commit is pushed.
+The primary CI workflow. Runs on all pull requests targeting `main`. Skips all checks for Dependabot
+PRs via a `guard` job that gates the remaining jobs on `github.actor != 'dependabot[bot]'`. Calls
+`lint-markdown.yml`, `doc-checks.yml`, and `pr-title.yml` as reusable workflows. Cancels in-progress
+runs for the same branch when a new commit is pushed.
 
 ### `lint-markdown.yml`
 


### PR DESCRIPTION
## Summary

Replaced an invalid `branches-ignore` filter (which cannot coexist with `branches`
in GitHub Actions) with a `guard` job that gates all CI checks on
`github.actor != 'dependabot[bot]'`. When Dependabot opens a PR, the guard is
skipped and all dependent jobs are automatically skipped too.

## Changes

- Removed broken `branches-ignore: dependabot/**` from the `pull_request` trigger
- Added a `guard` job with `if: ${{ github.actor != 'dependabot[bot]' }}`
- Added `needs: guard` to `lint-markdown`, `doc-checks`, and `pr-title` jobs
- Updated `docs/process/ci-pipeline.md` to document the Dependabot skip behavior

## Verification

Reviewed against GitHub Actions docs — `branches` and `branches-ignore` are
mutually exclusive filters; the guard job pattern is the correct actor-based
approach. Syntax validated manually. Doc passed `format:md` and `lint:md`.

## Related

Closes #24