### PR TITLE
chore(infra): add .claudeignore to scope Claude's file view

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,6 @@
+package-lock.json
+
+# Build artifacts — uncomment when application code is added
+# dist/
+# build/
+# .cache/

--- a/docs/technologies/stack.md
+++ b/docs/technologies/stack.md
@@ -3,7 +3,7 @@ title: Technology Stack
 doc_type: technology
 status: accepted
 owners: ["@julian-cardone"]
-last_reviewed: 2026-04-15
+last_reviewed: 2026-04-27
 related:
   [
     "docs/adrs/0003-ai-assisted-development.md",
@@ -36,7 +36,8 @@ including multi-file edits, documentation drafting, and codebase reasoning. It o
 terminal and as a VS Code extension.
 
 Claude Code reads `CLAUDE.md` at the repository root as its primary instruction file. All agent
-behavior is governed by the constraints and capabilities defined in `docs/agents/`.
+behavior is governed by the constraints and capabilities defined in `docs/agents/`. Use
+`.claudeignore` to exclude files and directories from Claude's view of the repository.
 
 ### GitHub Copilot
 


### PR DESCRIPTION
## Summary

Adds a `.claudeignore` file to exclude `package-lock.json` from Claude Code's view of the
repository, and updates `docs/technologies/stack.md` to document the file. Claude Code already
respects `.gitignore` (so `node_modules/` is already excluded), but `package-lock.json` is
git-tracked and has no semantic value for the agent. Commented-out entries for common build
artifact directories are included as a forward-looking pattern for when application code is added.

## Changes

- Created `.claudeignore` at repo root excluding `package-lock.json`
- Added one sentence to the Claude Code section of `docs/technologies/stack.md` noting the file
- Updated `last_reviewed` on `stack.md` to today

## Verification

`npm run format:md` and `npm run lint:md` both pass clean. Validated frontmatter and all referenced
file paths in `stack.md`.

## Related

Closes #26