### PR TITLE
chore(process): improve /start command reliability and clarity

### DIFF
--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -38,6 +38,16 @@ Note the issue number from the output URL.
 
 ## 3 — Create the branch
 
+Ensure main is up to date before branching:
+
+```bash
+git checkout main
+git pull origin main
+```
+
+If `git pull` reports conflicts or exits with a non-zero status, stop immediately and report the
+error. Do not proceed until main is clean.
+
 Slug: lowercase title, hyphens only, no special characters, drop filler words, ~5 words max.
 
 Format: `issue-<number>-<slug>`

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -50,7 +50,15 @@ git checkout -b issue-<number>-<slug> main
 
 ```bash
 gh project item-add 1 --owner @me --url <issue-url>
+sleep 3
 ```
+
+Query the project to get IDs. Extract:
+
+- `projectId` — the project node ID
+- `itemId` — the item where `content.number` matches the issue number
+- `statusFieldId` — the `id` of the field named "Status"
+- `inProgressOptionId` — the `id` of the option named "In Progress"
 
 ```bash
 gh api graphql -f query='
@@ -77,19 +85,26 @@ gh api graphql -f query='
 }'
 ```
 
+Verify the item is present before proceeding. If the issue number is not found in the items list,
+wait 3 seconds and re-query. Retry up to 3 times before stopping with an error.
+
+Then update status:
+
 ```bash
 gh api graphql -f query='
 mutation {
   updateProjectV2ItemFieldValue(input: {
-    projectId: "<project-id>"
-    itemId: "<item-id>"
-    fieldId: "<status-field-id>"
-    value: { singleSelectOptionId: "<in-progress-option-id>" }
+    projectId: "<projectId>"
+    itemId: "<itemId>"
+    fieldId: "<statusFieldId>"
+    value: { singleSelectOptionId: "<inProgressOptionId>" }
   }) {
     projectV2Item { id }
   }
 }'
 ```
+
+If the mutation returns errors, print them and stop.
 
 ## 5 — Print summary
 


### PR DESCRIPTION
## Summary

Hardens the `/start` command based on issues observed during a test run. Adds a pull-before-branch
step, retry logic for the project board query, and error handling for the status mutation.

## Changes

- Pull `main` before branching, with a hard stop if conflicts are detected
- Add `sleep 3` after `gh project item-add` to allow GitHub indexing before querying
- Add retry loop (up to 3×) for the project query in case the item hasn't propagated yet
- Add explicit error check on the status mutation
- Rename placeholder variables to camelCase for consistency with GraphQL conventions

## Related

Closes #34