### PR TITLE
chore(process): improve /pr command pre-flight instructions

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -5,10 +5,11 @@ Open a pull request for the current branch.
 ## Pre-flight
 
 1. Extract `<id>` from the branch name (`issue-<id>-<slug>`).
-1. Run `gh issue view <id>` — confirm it exists and capture: title, assignees, labels.
-1. Run `git status` — if there are uncommitted changes, run
+2. Run `gh issue view <id>` — confirm it exists and capture: title, assignees, labels. If the issue
+   is not found, stop immediately and report the error.
+3. Run `git status` — if there are uncommitted changes, run
    `git add -A && git commit -m "<type>(<scope>): <brief description>"`.
-1. Run `git push`.
+4. Run `git push`.
 
 ## Labels
 

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -38,6 +38,16 @@ Note the issue number from the output URL.
 
 ## 3 — Create the branch
 
+Ensure main is up to date before branching:
+
+```bash
+git checkout main
+git pull origin main
+```
+
+If `git pull` reports conflicts or exits with a non-zero status, stop immediately and report the
+error. Do not proceed until main is clean.
+
 Slug: lowercase title, hyphens only, no special characters, drop filler words, ~5 words max.
 
 Format: `issue-<number>-<slug>`

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -50,7 +50,15 @@ git checkout -b issue-<number>-<slug> main
 
 ```bash
 gh project item-add 1 --owner @me --url <issue-url>
+sleep 3
 ```
+
+Query the project to get IDs. Extract:
+
+- `projectId` — the project node ID
+- `itemId` — the item where `content.number` matches the issue number
+- `statusFieldId` — the `id` of the field named "Status"
+- `inProgressOptionId` — the `id` of the option named "In Progress"
 
 ```bash
 gh api graphql -f query='
@@ -77,19 +85,26 @@ gh api graphql -f query='
 }'
 ```
 
+Verify the item is present before proceeding. If the issue number is not found in the items list,
+wait 3 seconds and re-query. Retry up to 3 times before stopping with an error.
+
+Then update status:
+
 ```bash
 gh api graphql -f query='
 mutation {
   updateProjectV2ItemFieldValue(input: {
-    projectId: "<project-id>"
-    itemId: "<item-id>"
-    fieldId: "<status-field-id>"
-    value: { singleSelectOptionId: "<in-progress-option-id>" }
+    projectId: "<projectId>"
+    itemId: "<itemId>"
+    fieldId: "<statusFieldId>"
+    value: { singleSelectOptionId: "<inProgressOptionId>" }
   }) {
     projectV2Item { id }
   }
 }'
 ```
+
+If the mutation returns errors, print them and stop.
 
 ## 5 — Print summary
 


### PR DESCRIPTION
## Summary

Small fix to the `/pr` command pre-flight steps: numbered list items are now consistently ordered
(1→4) and step 2 now includes an explicit stop instruction when the issue is not found.

## Changes

- Number pre-flight steps sequentially (was using repeated `1.`)
- Add "If the issue is not found, stop immediately and report the error" to step 2

## Related

Closes #36