### PR TITLE
docs(process,infra): clarify one-to-one workflow model and fix commands

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -4,8 +4,8 @@ Open a pull request for the current branch.
 
 ## Pre-flight
 
-1. Extract `<id>` from the branch name (`issue-<id>-<slug>`). If the branch name does not match
-   this format, stop immediately and report the error. Do not create an issue.
+1. Extract `<id>` from the branch name (`issue-<id>-<slug>`). If the branch name does not match this
+   format, stop immediately and report the error. Do not create an issue.
 2. Run `gh issue view <id>` — confirm it exists and capture: title, assignees, labels. If the issue
    is not found, stop immediately and report the error.
 3. Run `git status` — if there are uncommitted changes, run
@@ -16,19 +16,24 @@ Open a pull request for the current branch.
 
 Copy all `type:*` and `scope:*` labels from the issue directly onto the PR.
 
-Also add these based on `git diff --name-only`:
+Also add these based on `git diff main...HEAD --name-only`:
 
-| If diff contains        | Add label        |
-| ----------------------- | ---------------- |
-| `package.json`/lockfile | `dependencies`   |
-| `.github/workflows/`    | `github_actions` |
-| `.js`/`.ts` files       | `javascript`     |
+| If diff contains         | Add label        |
+| ------------------------ | ---------------- |
+| `package.json`/lockfile  | `dependencies`   |
+| `.github/workflows/`     | `github_actions` |
+| `.js`/`.ts`/`.tsx` files | `javascript`     |
 
 ## Title
 
 `<type>(<scope>): <short description>`
 
 - Type: map `type:*` label → `docs` `feat` `fix` `chore` `refactor` `test` `ci`
+  - `type:doc` → `docs`
+  - `type:adr` → `docs`
+  - `type:design` → `docs`
+  - `type:tech-debt` → `refactor`
+  - `type:chore` → `chore`
 - Scope: map `scope:*` label → `docs` `process` `system-design` `infra`
 
 ## Create
@@ -38,20 +43,36 @@ gh pr create \
   --title "<title>" \
   --assignee "<assignee from issue, or @me if unassigned>" \
   --label "<labels>" \
-  --project "app" \
   --body "<body>"
 ```
 
-Use the body template below. Do not self-approve. Do not merge.
+Do not add `--project`. Pull requests are not tracked on the project board — only issues are. Do not
+self-approve. Do not merge.
 
 ## Body template
 
 ```markdown
 ## Summary
 
+<!-- What changed and why -->
+
 ## Changes
+
+<!-- List of specific changes made -->
 
 ## Related
 
 Closes #<id>
+
+## Documentation Updates
+
+<!-- Note any documentation updates, or write "Not applicable" -->
+
+## ADR Requirement
+
+<!-- Note whether an ADR was created, superseded, or not required -->
+
+## Definition of Done
+
+<!-- Confirm the relevant done criteria were satisfied -->
 ```

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -59,7 +59,7 @@ git checkout -b issue-<number>-<slug> main
 ## 4 — Add to project board and set "In Progress"
 
 ```bash
-gh project item-add 1 --owner @me --url <issue-url>
+gh project item-add 1 --owner "@me" --url <issue-url>
 sleep 3
 ```
 
@@ -77,8 +77,7 @@ gh api graphql -f query='
     projectV2(number: 1) {
       id
       items(first: 50) {
-        nodes {
-          id
+        nodes {          id
           content { ... on Issue { number } }
         }
       }

--- a/docs/process/git-workflow.md
+++ b/docs/process/git-workflow.md
@@ -3,8 +3,9 @@ title: Git Workflow
 doc_type: process
 status: accepted
 owners: ["@julian-cardone"]
-last_reviewed: 2026-05-02
-related: ["docs/process/pr-format.md", "docs/agents/constraints.md"]
+last_reviewed: 2026-05-15
+related:
+  ["docs/process/pr-format.md", "docs/process/project-management.md", "docs/agents/constraints.md"]
 tags: [git, workflow, process]
 ---
 
@@ -13,14 +14,38 @@ tags: [git, workflow, process]
 This document defines the branching and merge model for the repository. It is the source of truth
 for branch naming and merge strategy.
 
-For prohibitions on direct pushes, force pushes, and self-merging, see
-[Agent Constraints](../agents/constraints.md). For pull request structure, see
+For project tracking, issue requirements, and board usage, see
+[Project Management](./project-management.md). For prohibitions on direct pushes, force pushes, and
+self-merging, see [Agent Constraints](../agents/constraints.md). For pull request structure, see
 [Pull Request Format](./pr-format.md).
 
 ## Branching Model
 
 The repository follows a trunk-based workflow. `main` is the default branch. All changes are made on
 a non-target branch and merged via pull request.
+
+Each non-trivial unit of work must start from a GitHub issue. The issue defines the intent, scope,
+and acceptance criteria for the work. The branch implements that issue.
+
+## One Issue, One Branch, One Pull Request
+
+The default repository workflow is one-to-one:
+
+```text
+issue → branch → pull request → merge → done
+```
+
+Each issue must map to:
+
+- One primary branch.
+- One primary pull request.
+- One merged change on `main`.
+
+This keeps human and agentic workflows simple, reviewable, and easy to trace.
+
+If work appears too large for one pull request, split it into multiple smaller issues before work
+begins. Do not use one issue as an epic for multiple pull requests unless the process is explicitly
+changed.
 
 ### Branch Naming Convention
 
@@ -43,15 +68,21 @@ issue-27-update-architecture-diagram
 ### Rules
 
 - A branch must correspond to an existing issue.
+- A branch must have one primary issue.
 - Branch names must be lowercase, hyphen-separated.
 - Slugs should be concise.
+- Branches should be deleted after the pull request is merged.
 
 ## Merge Strategy
 
 Pull requests are merged into `main` using **squash merge**. This produces a single clean commit per
 issue and a direct mapping between issue and merged change.
 
+The pull request title becomes the squash commit message. The pull request description preserves the
+context, reasoning, and issue linkage.
+
 ## Enforcement
 
 The workflow is enforced through branch protection rules, required pull request reviews, CODEOWNERS
-routing, and required status checks. These controls are configured in repository settings.
+routing, required status checks, and pull request title validation. These controls are configured in
+repository settings.

--- a/docs/process/pr-format.md
+++ b/docs/process/pr-format.md
@@ -3,8 +3,13 @@ title: Pull Request Format
 doc_type: process
 status: accepted
 owners: ["@julian-cardone"]
-last_reviewed: 2026-05-02
-related: ["docs/process/git-workflow.md", "docs/process/done-criteria.md"]
+last_reviewed: 2026-05-15
+related:
+  [
+    "docs/process/git-workflow.md",
+    "docs/process/project-management.md",
+    "docs/process/done-criteria.md",
+  ]
 tags: [workflow, git, process]
 ---
 
@@ -16,6 +21,9 @@ before merging, see [Definition of Done](./done-criteria.md).
 The repository uses squash merge. Every pull request becomes a single commit on `main`, and the pull
 request title becomes the squash commit message. Individual development commits are unconstrained
 and do not appear in permanent history.
+
+Each pull request must have one primary linked issue. The issue tracks the work; the pull request
+records the reviewed implementation.
 
 ---
 
@@ -37,7 +45,7 @@ chore(ci): fix required file paths in doc-checks workflow
 fix(adrs): correct broken cross-reference in ADR-0004
 ```
 
-The title is the permanent commit record. It must accurately summarize the change.
+The title is the permanent commit record. It must accurately summarize the merged change.
 
 ---
 
@@ -54,7 +62,19 @@ The title is the permanent commit record. It must accurately summarize the chang
 
 ## Related
 
-<!-- Closes #<id> -->
+Closes #<id>
+
+## Documentation Updates
+
+<!-- Note any documentation updates, or write "Not applicable" -->
+
+## ADR Requirement
+
+<!-- Note whether an ADR was created, superseded, or not required -->
+
+## Definition of Done
+
+<!-- Confirm the relevant done criteria were satisfied -->
 ```
 
 The pull request description is the permanent record of context, reasoning, and issue references for
@@ -65,11 +85,26 @@ which remains accessible on GitHub after merge.
 
 ## Issue Linking
 
-Issue references belong in the description, not in the title. Use GitHub's closing keywords:
+Issue references belong in the description, not in the title.
+
+Because the repository uses a one-issue, one-pull-request workflow, each pull request must close its
+primary issue using GitHub's closing keywords:
 
 ```text
 Closes #42
 ```
 
-This closes the issue automatically on merge and keeps the title clean for the commit record. Issue
-linking is required for all pull requests.
+This closes the issue automatically when the pull request is merged and keeps the title clean for
+the commit record.
+
+Do not use non-closing references such as `Refs #42`, `Related to #42`, or `Part of #42` for the
+primary issue. Those references are only appropriate for secondary context and must not replace the
+required closing reference.
+
+## Pull Request Board Usage
+
+Pull requests should not be added to the project board by default.
+
+The project board tracks issues as the canonical units of work. A pull request is linked from the
+issue and represents the implementation review for that issue. Adding both the issue and pull
+request to the board creates duplicate tracking for the same work.

--- a/docs/process/project-management.md
+++ b/docs/process/project-management.md
@@ -3,16 +3,18 @@ title: Project Management
 doc_type: process
 status: accepted
 owners: ["@julian-cardone"]
-last_reviewed: 2026-05-02
+last_reviewed: 2026-05-15
 related: ["docs/process/git-workflow.md", "docs/process/pr-format.md"]
 tags: [workflow, governance, process]
 ---
 
 # Project Management
 
-This document defines how work is initiated, categorized, and completed within the repository.
+This document defines how work is initiated, categorized, tracked, and completed within the
+repository.
 
-All work must originate from a GitHub issue.
+Issues are the canonical units of work. Pull requests are the reviewed implementation records for
+those issues. The project board tracks issues, not pull requests.
 
 ## Issues Are Required
 
@@ -22,12 +24,34 @@ An issue must exist before:
 - Opening a pull request.
 - Drafting an Architecture Decision Record.
 - Making non-trivial documentation changes.
+- Starting agentic work that changes repository contents.
 
 Each issue represents a single unit of work.
 
-Each issue must map to a single primary branch.
+Each issue must map to:
 
-Issues serve as the canonical record of intent.
+- One primary branch.
+- One primary pull request.
+
+Issues serve as the canonical record of intent, scope, acceptance criteria, and status.
+
+Small typo fixes or trivial housekeeping may be grouped into an existing issue when appropriate, but
+non-trivial work must not bypass the issue workflow.
+
+## One-to-One Work Model
+
+The default project model is:
+
+```text
+one issue → one branch → one pull request
+```
+
+This keeps project tracking simple and prevents duplicate state across issues, branches, pull
+requests, and the project board.
+
+If a planned issue becomes too large to review comfortably, split it into smaller issues before
+implementation continues. Do not treat a single issue as an epic containing multiple pull requests
+unless the workflow is explicitly revised.
 
 ## Required Labels
 
@@ -43,10 +67,13 @@ Describes the nature of the work.
 Examples:
 
 - `type:doc` — writing or changing documentation
-- `type:adr` — the work will produce an Architecture Decision Record (explicit decision required)
-- `type:design` — systems design work (pre-code)
+- `type:adr` — the work will produce an Architecture Decision Record
+- `type:design` — systems design work before implementation
+- `type:feature` — user-facing or system-facing functionality
+- `type:bug` — defect correction
 - `type:chore` — setup, tooling, housekeeping, configuration
-- `type:tech-debt` — cleanup, refactors, paydown
+- `type:refactor` — structure change without intended behavior change
+- `type:tech-debt` — cleanup, simplification, or paydown
 
 ### Scope
 
@@ -55,22 +82,35 @@ Describes the area impacted.
 Examples:
 
 - `scope:docs` — documentation system itself
-- `scope:infra` — CI, tooling, hosting
+- `scope:frontend` — frontend application code
+- `scope:backend` — backend application code
+- `scope:infra` — CI, tooling, hosting, deployment, or cloud infrastructure
 - `scope:process` — standards, workflow, governance
-- `scope:system-design` — architecture and design work
+- `scope:architecture` — architecture and system boundaries
+- `scope:ai` — AI agents, model integrations, prompts, tools, or automation
 
 Labels must not be omitted.
+
+## Project Board
+
+The project board is an issue-level planning and status board.
+
+Only issues should be added to the project board by default. Pull requests should not be added as
+separate board items because they duplicate the issue they implement.
+
+A pull request is linked from its issue and moves the issue through the review and completion
+states.
 
 ## Project Board States
 
 Work progresses through the following states:
 
-1. **Backlog** – Identified but not started.
-2. **Ready** – Ready to be worked on.
-3. **In Progress** – Actively being worked on.
-4. **Blocked** – Work cannot proceed due to an external dependency.
-5. **Review** – A pull request has been opened and is awaiting approval and merge.
-6. **Done** – Merged into `main`.
+1. **Backlog** – Identified but not yet scoped or prioritized.
+2. **Ready** – Scoped, labeled, and ready to be worked on.
+3. **In Progress** – A branch exists or active work has started.
+4. **Blocked** – Work cannot proceed due to a decision, dependency, or external constraint.
+5. **Review** – The pull request has been opened and is awaiting approval and merge.
+6. **Done** – The pull request has been merged into `main` and the issue is closed.
 
 State transitions must reflect reality.
 
@@ -81,27 +121,44 @@ An issue must not be moved to **Done** until its corresponding pull request is m
 ### `/start`
 
 Run `/start <description>` at the beginning of every unit of work before touching any files.
-Automates project setup: creates the issue, applies labels, creates the branch, and moves the issue
-to **In Progress** on the project board.
+
+The command should automate project setup by:
+
+1. Creating the issue.
+2. Applying required labels.
+3. Adding the issue to the project board.
+4. Creating the branch from the issue.
+5. Moving the issue to **In Progress**.
+
+The command should not create a pull request until implementation work has been completed.
 
 ## Workflow
 
 The standard workflow is:
 
-1. Create issue.
+1. Create an issue.
 2. Apply required labels.
-3. Add issue to the project workboard.
-4. Create branch linked to issue.
-5. Open pull request.
-6. Review and merge.
-7. The issue is automatically closed when the pull request is merged.
+3. Add the issue to the project board.
+4. Move the issue to **Ready** when it is scoped.
+5. Create a branch linked to the issue.
+6. Move the issue to **In Progress**.
+7. Make changes on the branch.
+8. Open a pull request that uses `Closes #<id>` for the issue.
+9. Move the issue to **Review**.
+10. Review and merge the pull request.
+11. Confirm the issue is closed and moved to **Done**.
 
 Branch naming, pull request requirements, and merge strategy are defined separately.
 
 ## Closure Rules
 
-Issues must be closed through pull request merge using GitHub's automatic closing mechanism.
+Issues should be closed through pull request merge using GitHub's automatic closing mechanism:
 
-Issues must not be manually closed unless the work is explicitly abandoned.
+```text
+Closes #<id>
+```
+
+Issues must not be manually closed unless the work is explicitly abandoned, replaced, or no longer
+needed.
 
 Manual closure must include justification in a comment.


### PR DESCRIPTION
## Summary

Aligns process documentation and agent commands around the one-issue → one-branch → one-PR workflow model. Fixes the `/pr` command to stop adding PRs to the project board, expands the PR body template, and updates all related process docs to be consistent.

## Changes

- **`.claude/commands/pr.md`**: Use `git diff main...HEAD` for label detection; add `.tsx` to javascript label rule; add explicit `type:*` → commit-type mappings; remove `--project` flag from `gh pr create`; expand body template with Documentation Updates, ADR Requirement, and Definition of Done sections
- **`.claude/commands/start.md`**: Quote `@me` in `gh project item-add`; minor GraphQL formatting fix
- **`docs/process/git-workflow.md`**: Add "One Issue, One Branch, One Pull Request" section; clarify squash merge behavior; add branch deletion rule; update related docs list
- **`docs/process/pr-format.md`**: Add one-issue-per-PR rule; expand PR body template; strengthen issue linking rules (disallow `Refs #` as primary reference); add "Pull Request Board Usage" section
- **`docs/process/project-management.md`**: Clarify issues vs PRs on the board; add "One-to-One Work Model" and "Project Board" sections; expand label taxonomy (`type:feature`, `type:bug`, `type:refactor`; updated scopes); expand workflow steps and closure rules

## Related

Closes #43

## Documentation Updates

Updated `docs/process/git-workflow.md`, `docs/process/pr-format.md`, and `docs/process/project-management.md` to reflect the one-to-one workflow model consistently.

## ADR Requirement

Not required — no architectural decisions made, process documentation clarified.

## Definition of Done

- All modified files are consistent with each other
- Commands reflect updated process docs
- No PR is added to the project board