### PR TITLE
docs(system-design): Create ADR for frontend technologies and mobile dev skills

### DIFF
--- a/.claude/skills/frontend-philosophy/SKILL.md
+++ b/.claude/skills/frontend-philosophy/SKILL.md
@@ -3,7 +3,7 @@ name: frontend-philosophy
 description:
   Apply this repository's frontend architecture principles when designing, writing, or reviewing
   React components. Use whenever a component is being created or refactored, when deciding where
-  state should live, when extracting a feature component from a page, when introducing an
+  state should live, when extracting a feature component from a page or screen, when introducing an
   abstraction, when naming a new component, when deciding between context and prop passing, when
   writing a useEffect, when defining props or public interfaces, or when reviewing a PR for
   architectural issues. Trigger on casual phrasings too — "should this be a hook or a component",
@@ -12,13 +12,13 @@ description:
   rules here are specific about component layers (shared primitives vs. feature components), state
   ownership, the three-condition test for introducing abstractions, banned name patterns (`Manager`,
   `Handler`, `Wrapper`, `DataTable`), how effects are used, and the separation between backend and
-  frontend models. Applies to React on both web and mobile.
+  frontend models. Applies to React on both web and React Native on mobile.
 ---
 
 # Frontend Philosophy
 
-These are the architectural principles for React code in this repository. They apply whenever
-designing, writing, or reviewing components, hooks, and feature code.
+These are the architectural principles for React and React Native code in this repository. They
+apply whenever designing, writing, or reviewing components, hooks, and feature code.
 
 The full prose version lives at `docs/standards/frontend-philosophy.md` in the repository. This
 skill is the operational summary — consult the source doc for extended rationale.
@@ -26,9 +26,11 @@ skill is the operational summary — consult the source doc for extended rationa
 The architecture must remain minimal, durable, predictable, and scalable. Favor explicit structure,
 narrow ownership, and predictable refactoring over generic abstraction systems.
 
-This skill covers component architecture and ownership. For styling rules, see the CSS skill for
-your platform. For flex layout and overflow, see the layout skill for your platform. For folder
-layout, see the project structure skill.
+This skill covers component architecture and ownership. These principles are platform-agnostic — the
+same ownership, state, effect, and abstraction rules hold on web and mobile. Platform-specific
+concerns live elsewhere: for styling rules, see the styling skill for your platform; for flex layout
+and overflow, see the layout skill for your platform; for folder layout, see the project structure
+skill for your platform.
 
 ---
 
@@ -62,8 +64,9 @@ Every concern has a clear owner. Ambiguous ownership produces duplicated logic, 
 fragile behavior.
 
 A concern belongs to the lowest layer capable of managing it correctly. Each layer's ownership rules
-are defined in the document responsible for that layer — spatial and layout concerns in
-`web-layout`, folder and module boundaries in `project-structure`, styling concerns in `web-css`.
+are defined in the document responsible for that layer — spatial and layout concerns in the layout
+skill for your platform, folder and module boundaries in the project structure skill for your
+platform, styling concerns in the styling skill for your platform.
 
 ---
 
@@ -109,24 +112,28 @@ Names describe domain responsibility.
 
 ---
 
-## Pages
+## Pages and Screens
 
-Pages are route-level composition shells. They own:
+Pages (web) and screens (mobile) are the same role: route-level composition shells. On the web they
+are route components; on mobile they are the screens registered with a navigator. They own:
 
 1. Route-level layout
 2. Feature composition
-3. Page-level state
-4. Routing concerns
+3. Page- or screen-level state
+4. Routing / navigation concerns
 
-Workflow logic and section-level rendering belong in feature components, not pages.
+Workflow logic and section-level rendering belong in feature components, not in the page or screen.
 
-A block of JSX in a page must be extracted into a feature component when it:
+A block of markup in a page or screen must be extracted into a feature component when it:
 
 - Owns state
 - Manages a workflow
 - Represents a distinct visual section
 
-Pages stay composition-oriented, not content-heavy.
+Pages and screens stay composition-oriented, not content-heavy.
+
+The example below is web (`<div>` / `<button>`); on mobile the same rule holds with `<View>` /
+`<Pressable>` and an `EventScreen` composing the same feature components.
 
 ```tsx
 /* Wrong — page renders content and owns state directly. */
@@ -154,8 +161,8 @@ export default function EventPage() {
 }
 ```
 
-The page defines the surface and layout container. State, workflow, and rendering belong in the
-feature components.
+The page or screen defines the surface and layout container. State, workflow, and rendering belong
+in the feature components.
 
 ---
 
@@ -166,7 +173,7 @@ State lives at the lowest component that reasonably owns it.
 - Form values belong to the form.
 - Selection state belongs to the section managing selection.
 - Modal state belongs to the component opening the modal.
-- Route-level data belongs to the page.
+- Route-level data belongs to the page or screen.
 
 **State must not be duplicated.** Derived values are computed from source state, not copied into
 independent state variables. If a hook owns data, consuming components derive from that hook rather
@@ -195,7 +202,7 @@ If logic can be derived during render, it does not belong in an effect.
 Effects synchronize React state with:
 
 - Network requests
-- Browser APIs
+- Platform APIs (the browser DOM on web; native device modules on mobile)
 - Timers
 - External systems
 
@@ -231,7 +238,7 @@ Every component declares typed props. Implicit `any` is disallowed.
 ```tsx
 type ButtonProps = {
   variant: "primary" | "secondary";
-  onClick: () => void;
+  onPress: () => void; // onClick on web
   children: ReactNode;
 };
 ```
@@ -324,11 +331,12 @@ the parent can clear its own state in sync.
 
 ---
 
-## Tables
+## Tables and Lists
 
-Tables render rows and invoke callbacks. They do not fetch data or own workflow state.
+Tables (web) and lists (`FlatList` / `SectionList` on mobile) render rows and invoke callbacks. They
+do not fetch data or own workflow state.
 
-Tables accept:
+They accept:
 
 - Rows or items
 - Selected identifiers
@@ -382,7 +390,7 @@ through branching configuration.
 
 Recurring violations to watch for in review or when writing new code:
 
-- A page rendering content directly instead of composing feature components.
+- A page or screen rendering content directly instead of composing feature components.
 - State duplicated across a hook and a `useState` in a consuming component.
 - A `useEffect` that derives one local value from another instead of computing it in render.
 - A shared primitive accumulating feature-specific props or domain knowledge.
@@ -392,7 +400,7 @@ Recurring violations to watch for in review or when writing new code:
 - A boolean prop like `isSpecialMode` added instead of splitting the component.
 - `snake_case` field names appearing in a component file (missing mapper at the service boundary).
 - A form component navigating or making API calls itself instead of invoking parent callbacks.
-- A table component fetching its own data or owning modal state.
+- A table or list component fetching its own data or owning modal state.
 - Context used for short-distance prop passing rather than genuinely cross-cutting state.
 - Comments narrating what the code does instead of why it exists.
 
@@ -410,9 +418,10 @@ primary mechanisms by which the codebase remains maintainable as it grows.
 
 ## When to Consult the Related Standards
 
-- For styling rules, units, variants, and class naming: the CSS skill for your platform (`web-css`,
-  or the mobile equivalent when present).
-- For flex layout, scroll ownership, and constraint chains: the layout skill for your platform
-  (`web-layout`, or the mobile equivalent when present).
+- For styling rules, units, variants, and style/class naming: the styling skill for your platform —
+  `web-css` (web) or `mobile-styles` (mobile).
+- For flex layout, scroll ownership, and constraint chains: the layout skill for your platform —
+  `web-layout` (web) or `mobile-layout` (mobile).
 - For where files live, the boundary between `components/ui/` and `features/`, and the
-  public-surface import rules: `project-structure`.
+  public-surface import rules: the project structure skill for your platform —
+  `web-project-structure` (web) or `mobile-project-structure` (mobile).

--- a/.claude/skills/mobile-layout/SKILL.md
+++ b/.claude/skills/mobile-layout/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: mobile-layout
+description: Apply this repository's React Native flex layout conventions when writing or debugging layout for mobile components. Use whenever a layout is being built or fixed — flex columns, flex rows, scrollable regions, side-by-side views, list rows, screen shells, modals, bottom sheets, headers, card bodies, tab screens — and whenever a layout symptom appears: content escaping its container, text that won't truncate, a row laid out vertically, a view that won't shrink, stacked scroll views, a list that warns about nesting, or a screen that overlaps the notch or home indicator. Trigger on casual phrasings too — "make this scroll", "this is overflowing", "the row is blowing out", "why won't this shrink", "fix the layout". Do not rely on general web flex knowledge here: React Native's flex defaults differ from the web (flexDirection defaults to column, flexShrink defaults to 0, flex is a single number), scrolling is owned by ScrollView/FlatList rather than an overflow property, and screens must account for safe-area insets. The standard recipes here are the approved patterns; deviation requires a justified reason. Applies to React Native mobile components. Web has its own conventions.
+---
+
+# Mobile Layout
+
+These are the flex layout mechanics for React Native in this repository. Follow them whenever
+writing or fixing layout, debugging overflow or scroll issues, or deciding which component owns
+sizing and clipping.
+
+The layout philosophy is durable, predictable, and composition-oriented — identical in spirit to the
+web standard. Layout behavior must remain stable under refactoring. Components must behave
+consistently regardless of where they are rendered.
+
+This skill covers layout, shrinking, and scroll ownership. For unit choices, variants, and tokens,
+see the `mobile-styles` skill. For component architecture and ownership boundaries, see
+`mobile-frontend-philosophy`.
+
+React Native uses Flexbox as its only layout system (no Grid). Every `<View>` is a flex container by
+default — there is no `display: flex` to set. The mechanics resemble web flexbox but the defaults
+differ in ways that bite web developers, and those differences are the subject of this skill.
+
+---
+
+## How React Native Flex Differs from the Web
+
+Four defaults differ from web CSS. Internalize these — most mobile layout bugs trace to one of them.
+
+| Property        | Web default | React Native default |
+| --------------- | ----------- | -------------------- |
+| `flexDirection` | `row`       | **`column`**         |
+| `flexShrink`    | `1`         | **`0`**              |
+| `alignContent`  | `stretch`   | `flex-start`         |
+| `flex`          | shorthand   | **single number**    |
+
+The first two are the load-bearing ones. Children stack **vertically** by default, and they **do not
+shrink** by default.
+
+---
+
+## Layout Ownership
+
+Layout responsibility is divided across three roles. Preserve the boundary.
+
+| Role                  | Owns                                                 |
+| --------------------- | ---------------------------------------------------- |
+| Screen                | Route-level layout and major content arrangement     |
+| Layout container      | Constraints, scroll boundaries, clipping, safe areas |
+| Reusable UI component | Internal structure and intrinsic shape               |
+
+A **layout container** is any wrapper whose job is to constrain and arrange child content: a screen
+shell, a modal body, a bottom sheet, a card body, a tab screen, a section wrapper.
+
+Reusable components do not own:
+
+- Scroll boundaries (no `ScrollView`/`FlatList` wrapping themselves)
+- Safe-area insets
+- Screen-level positioning
+- Layout orchestration
+- Hard-coded external sizing
+
+Reusable components stay layout-agnostic regardless of where the style is written — a reusable
+component's styles must not define external sizing, scroll boundaries, or screen-level positioning.
+Screens and layout containers constrain them.
+
+---
+
+## Constraint Chains
+
+Flex layouts operate through chains of constraints. A missing constraint at any level breaks
+behavior below it.
+
+Most React Native layout bugs trace to one of:
+
+- A child that should shrink but has `flexShrink: 0` (the default)
+- A row that forgot `flexDirection: 'row'`
+- Incorrect `alignItems`
+- A reusable component owning its own scroll
+- Multiple competing scroll containers
+
+Debugging focuses on locating the broken constraint rather than masking the symptom.
+
+---
+
+## flexDirection Defaults to Column
+
+A `<View>` lays its children out **top to bottom** by default. Coming from the web, this is the most
+common early surprise: a "row" of items will stack vertically until you say otherwise.
+
+```tsx
+// Children stack vertically — the default
+<View>{...}</View>
+
+// Children sit side by side — must be explicit
+<View style={{ flexDirection: "row" }}>{...}</View>
+```
+
+Set `flexDirection: 'row'` explicitly for any horizontal arrangement. Do not assume row.
+
+---
+
+## The flexShrink Rule
+
+This is the mobile counterpart of the web `min-width: 0` / `min-height: 0` rule — and it is
+**inverted**. On the web, children default to `flexShrink: 1` and the bug is that `min-*: auto`
+stops them from shrinking. In React Native, children default to **`flexShrink: 0`**, so they refuse
+to shrink at all. The result:
+
+- Text overflows its container or pushes siblings off-screen.
+- A long row stretches past the screen edge.
+- A child ignores the space pressure entirely.
+
+Any flex child that must shrink declares one of:
+
+```ts
+{
+  flexShrink: 1;
+} // shrink only
+{
+  flex: 1;
+} // grow AND shrink (flex: 1 = flexGrow 1, flexShrink 1, flexBasis 0)
+```
+
+`flex: 1` already includes `flexShrink: 1`, so a child sized with `flex: 1` will shrink. The
+explicit `flexShrink: 1` is for children that should shrink without growing. Apply at **every level
+of the chain that must shrink** — skipping one level breaks shrinking below it.
+
+`minWidth: 0` occasionally helps on nested row wrappers as a belt-and-suspenders measure, but in
+React Native the primary lever is `flexShrink`, not `minWidth`/`minHeight`.
+
+---
+
+## Text Truncation
+
+Text is the most frequent shrink offender. To truncate cleanly:
+
+1. The text's container must be allowed to shrink (`flex: 1` or `flexShrink: 1`).
+2. The `<Text>` itself takes `numberOfLines` (and optionally `ellipsizeMode`).
+
+```tsx
+<View style={{ flexDirection: "row" }}>
+  <View style={{ flex: 1 }}>
+    <Text numberOfLines={1}>A very long event title that should truncate…</Text>
+  </View>
+  <Icon />
+</View>
+```
+
+Without the shrinking wrapper, the text pushes the icon off-screen. Without `numberOfLines`, it
+wraps instead of truncating.
+
+---
+
+## alignItems and Cross-Axis Sizing
+
+`alignItems` controls cross-axis sizing. The default is `stretch`, which lets children fill the
+container's cross-axis width (in a column) or height (in a row).
+
+Changing `alignItems` to `center`, `flex-start`, or `flex-end` makes children intrinsically sized on
+the cross axis rather than stretched. Use `center` only when intrinsic sizing is intentionally
+desired — not on a container whose children are meant to fill and shrink within a constrained width.
+
+---
+
+## Scroll Ownership
+
+There is no `overflow: 'auto'` or `overflow-y` scrolling in React Native. Scrolling is a
+**component**: `ScrollView` for small, bounded content, and `FlatList` (or `SectionList`) for long
+or unbounded lists, which virtualize for performance.
+
+Scroll boundaries belong to screens or layout containers. Reusable components do not wrap themselves
+in a scroll view.
+
+```tsx
+// Avoid — the component owns its own scrolling
+<EventList />   // ScrollView baked inside
+
+// Preferred — the layout container owns the scroll boundary
+<View style={{ flex: 1 }}>
+  <FlatList data={events} renderItem={renderEvent} />
+</View>
+```
+
+Each scrollable region has **exactly one** scroll container. Nesting scroll views of the same
+orientation causes broken gestures, unreachable content, and the runtime warning that a
+VirtualizedList should not be nested inside a plain ScrollView of the same orientation. If you need
+a scrolling list with a scrolling header, use the list's own header prop (e.g.
+`ListHeaderComponent`) rather than nesting.
+
+A `ScrollView` (or `FlatList`) needs a bounded parent to define its viewport — typically a parent
+with `flex: 1`. Inner padding for a `ScrollView` goes on `contentContainerStyle`, not `style`.
+
+---
+
+## Safe Areas
+
+Phones have notches, status bars, and home indicators. Content must not render under them. This has
+no web equivalent and is a hard requirement on every screen.
+
+Wrap screen-level content so it respects the device's safe-area insets (via
+`react-native-safe-area-context` — `SafeAreaView` or the `useSafeAreaInsets` hook). Apply insets at
+the **screen / layout-container level**, not inside reusable components. A reusable card should
+never know about the notch.
+
+```tsx
+const insets = useSafeAreaInsets();
+<View style={{ flex: 1, paddingTop: insets.top }}>{...}</View>;
+```
+
+---
+
+## Sizing: flex Is a Single Number
+
+React Native's `flex` accepts only a single number — the web shorthand does **not** port. The web
+recipe `flex: 1 14rem` (grow, shrink, preferred basis) is invalid here. When you need a preferred
+size with shrink-and-grow behavior, set the longhand properties:
+
+```ts
+// Web (does NOT work in React Native):
+{ flex: "1 1 14rem" }
+
+// React Native equivalent:
+{ flexGrow: 1, flexShrink: 1, flexBasis: 224 }
+```
+
+Avoid hard `width` values for flexible regions. Use `flexBasis` for a preferred starting size and
+let grow/shrink distribute the rest. Reserve fixed `width` for genuinely fixed-size elements (an
+avatar, an icon button).
+
+---
+
+## Standard Recipes
+
+### Fixed header with scrolling content
+
+```tsx
+<View style={styles.screen}>
+  <View style={styles.header}>{...}</View>
+  <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
+    {...}
+  </ScrollView>
+</View>
+```
+
+```ts
+const styles = StyleSheet.create({
+  screen: { flex: 1 }, // fills the screen, column by default
+  header: {}, // sizes to content; no flex
+  scroll: { flex: 1 }, // fills remaining space, owns scrolling
+  scrollContent: { padding: 16 }, // inner padding goes here, not on `scroll`
+});
+```
+
+The header sizes to its content. The scroll region fills the rest and owns scrolling.
+
+### Side-by-side regions
+
+```ts
+const styles = StyleSheet.create({
+  row: { flexDirection: "row" }, // must be explicit
+  left: { flex: 1 }, // grow + shrink
+  right: { flex: 1 },
+});
+```
+
+Each region grows and shrinks independently. Long content in one does not push the other off-screen.
+
+### Row with a truncating label and a fixed action
+
+```ts
+const styles = StyleSheet.create({
+  row: { flexDirection: "row", alignItems: "center" },
+  label: { flex: 1 }, // shrinks; pair with numberOfLines on the Text
+  action: { flexShrink: 0 }, // fixed; never shrinks (also the default)
+});
+```
+
+---
+
+## Decorative Clipping Only
+
+`overflow: 'hidden'` is permitted only for decorative clipping — most often clipping children to a
+rounded corner:
+
+```ts
+{ borderRadius: 16, overflow: "hidden" }
+```
+
+Android note: clipping a child (e.g. an `<Image>`) to a parent's `borderRadius` requires
+`overflow: 'hidden'` on the parent. Be aware this conflicts with `elevation` shadows on Android — a
+view cannot both cast an elevation shadow and clip its overflow on the same node; split them across
+two views when you need both.
+
+Never use `overflow: 'hidden'` to suppress a layout bug. If content escapes a container, the cause
+is upstream — usually a missing `flexShrink: 1`, a forgotten `flexDirection: 'row'`, or a wrong
+`alignItems`. Fix the chain; do not mask the symptom.
+
+---
+
+## Debugging Checklist
+
+Work the chain from outside in. The cause is almost always one of these:
+
+1. **A "row" of items is stacked vertically** → missing `flexDirection: 'row'` (the default is
+   column).
+
+2. **Text or a child blows past the screen edge or pushes siblings off** → the child is not
+   shrinking. Add `flexShrink: 1` (or `flex: 1`) at every level of the row chain that should shrink.
+   React Native defaults `flexShrink` to `0`.
+
+3. **Text won't truncate** → add `numberOfLines` to the `<Text>` and ensure its wrapper can shrink
+   (`flex: 1` / `flexShrink: 1`).
+
+4. **A child won't fill cross-axis width** → an ancestor uses `alignItems: 'center'` (or
+   `flex-start` / `flex-end`), making children intrinsically sized. Revert to `stretch` (the
+   default) on that ancestor if filling was intended.
+
+5. **Reusable component breaks in a new context** → the component owns its own scroll, safe-area
+   insets, or external sizing. Strip those and move them to the wrapping layout container.
+
+6. **Two scroll views fight, or a VirtualizedList-nesting warning appears** → scroll containers are
+   stacked. Remove the inner one; let one container own the boundary, or use the list's header prop.
+
+7. **Content renders under the notch or home indicator** → safe-area insets are missing at the
+   screen level. Wrap with safe-area handling.
+
+8. **You're reaching for `overflow: 'hidden'` to fix a layout problem** → stop. Find the missing
+   `flexShrink: 1`, `flexDirection: 'row'`, or correct `alignItems` upstream. `overflow: 'hidden'`
+   is only for decorative clipping.
+
+---
+
+## Mental Model
+
+```text
+Screen
+  owns route-level layout and safe-area insets
+
+Layout container
+  owns constraints, scroll boundaries (ScrollView / FlatList), and clipping
+
+Reusable UI component
+  owns structure and visual behavior — never scroll, safe areas, or external sizing
+
+Rows
+  require flexDirection: 'row' (column is the default)
+
+Children that must shrink
+  require flexShrink: 1 (the default is 0) — or flex: 1, which includes it
+
+Scrollable regions
+  are components (ScrollView / FlatList), exactly one per region
+```
+
+This model is the source of truth.
+
+---
+
+## When to Consult the Related Standards
+
+- For unit choices, variants, design tokens, style keys, and platform-specific shadows:
+  `mobile-styles`.
+- For component ownership boundaries, the `style` prop convention, and when a primitive should be
+  split: `mobile-frontend-philosophy`.
+- For where screens, layout containers, and feature components live in the folder tree:
+  `mobile-project-structure`.

--- a/.claude/skills/mobile-project-structure/SKILL.md
+++ b/.claude/skills/mobile-project-structure/SKILL.md
@@ -1,0 +1,402 @@
+---
+name: mobile-project-structure
+description:
+  Apply this repository's React Native folder and module conventions when creating files, organizing
+  code, deciding where something belongs, or reviewing structural choices on mobile. Use whenever a
+  new component, hook, service, screen, or feature is being added, when deciding between
+  `components/ui/` and `features/<feature>/components/`, when introducing a new feature folder, when
+  setting up a public surface (`index.ts`), when adding a screen to navigation, when promoting code
+  from feature-local to shared, when placing fonts or images, or when reviewing a PR for boundary
+  violations. Trigger on casual phrasings too — "where should I put this", "is this shared or
+  feature-specific", "where does this screen go", "where do fonts live", "can I import this from
+  here". Do not rely on general React project intuition here; React Native structure differs from
+  the web in load-bearing ways - the entry is `registerRootComponent(App)` not a DOM render, there
+  is no `router.tsx` route table (navigation is a navigator tree), there are no global CSS files
+  (design tokens live in a TS module), route-level units are screens not pages, and
+  fonts/images/icon/splash live in `assets/` and the Expo config. Applies to React Native mobile.
+  Web has its own conventions.
+---
+
+# Mobile Project Structure
+
+These are the folder and module conventions for React Native code in this repository. Follow them
+whenever creating files, deciding where code belongs, defining a module boundary, or reviewing
+structural placement.
+
+The project structure must remain scalable, predictable, and easy to navigate. A future engineer or
+AI agent must be able to determine where code belongs, what owns a concern, which modules are
+public, and which boundaries must remain isolated.
+
+This skill covers physical organization for a React Native app (Expo managed workflow, React
+Navigation). For component ownership and architectural rules, see `frontend-philosophy`. For styling
+and layout, see `mobile-styles` and `mobile-layout`.
+
+The shared spine of this structure — the `components/ui/` vs `features/` split, promotion rules,
+public surfaces, services, import rules, and folder discipline — is identical to the web standard.
+The differences are concentrated in the application entry, navigation, styling files, route-level
+naming, and assets. Those are the sections that diverge below.
+
+---
+
+## Reference Structure
+
+```text
+app.json (or app.config.ts)    # Expo config: app name, icon, splash, plugins
+index.js                       # Entry — registerRootComponent(App)
+assets/
+  fonts/                       # Bundled font files (expo-font)
+  images/                      # Bundled images, icon, splash source
+
+src/
+  components/
+    ui/                        # Shared UI primitives
+
+  features/
+    <feature-name>/
+      components/              # Feature components
+      hooks/                   # Feature-scoped hooks
+      lib/                     # Feature-scoped pure logic
+      models/                  # Feature domain models
+      screens/                 # Route-level screens
+
+  navigation/                  # Navigator tree + route param types
+
+  services/                    # Backend integrations
+  providers/                   # Context providers
+  hooks/                       # Cross-feature hooks
+  lib/                         # Cross-feature pure utilities
+
+  styles/
+    tokens.ts                  # Colors, spacing, radii, typography, shadows
+
+  App.tsx                      # Root shell: providers, navigation container
+```
+
+**Folders are not created before they contain files.** Structure emerges from real complexity, not
+from speculative scaffolding.
+
+---
+
+## Application Entry
+
+React Native has no DOM, no HTML document, and no global stylesheet to import — so the web's
+`index.tsx` / `router.tsx` / `App.tsx` triad does not apply. The mobile entry has two pieces:
+
+| File / dir        | Responsibility                                                                                                                   |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `index.js` (root) | The entry. Registers the root component: `registerRootComponent(App)`. No DOM render.                                            |
+| `App.tsx`         | Root shell. Sets up providers, `SafeAreaProvider`, `GestureHandlerRootView`, the `NavigationContainer`, theme, and font loading. |
+| `navigation/`     | The navigator tree (stack and tab navigators) and route param types. **Not** a route-config table.                               |
+
+`App.tsx` is the **only** top-level `.tsx` file under `src/`. It stays a thin shell — it wires up
+providers and hands rendering to the navigator. It does not own screen content or feature logic.
+
+There is no `router.tsx`. Navigation is expressed as a tree of navigator components (e.g.
+`RootNavigator` composing a tab navigator and stack navigators), not as a flat route configuration
+object. Route param types live alongside the navigator that owns them.
+
+> This structure assumes React Navigation (the navigation choice recorded in the frontend ADR). If
+> the project ever adopts file-based routing instead, the entry, the `navigation/` folder, and the
+> location of screens would all change — revisit this section if that decision is revisited.
+
+---
+
+## Shared and Feature Boundaries
+
+Shared code lives outside `features/` and is domain-agnostic.
+
+Feature code lives inside:
+
+```text
+features/<feature-name>/
+```
+
+The import rules:
+
+- Shared modules must not import from feature folders.
+- Feature modules may import from shared modules and services.
+- Feature modules must not import directly from unrelated feature folders.
+
+Cross-feature behavior is introduced through shared abstractions or service boundaries — only after
+reuse is proven.
+
+---
+
+## Promotion Rules
+
+Code stays local until reuse is proven.
+
+A module used by only one feature belongs in that feature. Promotion into shared areas
+(`components/ui/`, `hooks/`, `lib/`) requires:
+
+1. Proven reuse.
+2. Domain-agnostic behavior.
+3. Stable abstraction boundaries.
+
+Premature promotion creates fragile generic systems and weak ownership boundaries. When in doubt,
+leave it in the feature folder.
+
+---
+
+## Public Surfaces
+
+Every major boundary exposes a public surface through an `index.ts`:
+
+```text
+components/ui/index.ts
+features/events/index.ts
+services/events/index.ts
+```
+
+Consumers import through the public surface, not internal implementation files:
+
+```ts
+import { EventCard } from "@/features/events";
+import { Button } from "@/components/ui";
+```
+
+Screen components live inside `features/<feature>/screens/` and are part of the feature they serve.
+They are exported through the feature's `index.ts` so the navigator can register them without
+reaching into internal paths:
+
+```ts
+// features/events/index.ts
+export { EventScreen } from "./screens/EventScreen";
+
+// navigation/EventsStack.tsx
+import { EventScreen } from "@/features/events";
+```
+
+Internal implementation details stay private to their boundary. This is what allows internal
+refactoring without cascading dependency breakage. If a consumer is reaching into an internal file,
+the public surface is missing something — fix the surface, don't bypass it.
+
+---
+
+## Navigation
+
+Navigation lives in `src/navigation/`. It owns:
+
+- The navigator tree — a root navigator composing tab and stack navigators.
+- Route param type definitions, co-located with the navigator that declares the routes.
+
+Navigators register screens imported from feature public surfaces. They do not contain screen
+content themselves — a navigator file wires routes to screens and nothing more. Feature-specific
+workflow stays in the screen and its feature components, never in the navigator.
+
+Cross-cutting navigation concerns (deep-link config, the `NavigationContainer`, theme) are set up in
+`App.tsx`, not scattered across feature navigators.
+
+---
+
+## Services
+
+Services encapsulate backend integration. Components must not call backend APIs directly.
+
+A service folder structure:
+
+```text
+services/
+  events/
+    events.api.ts
+    events.mappers.ts
+    events.types.ts
+    index.ts
+```
+
+| File           | Responsibility                            |
+| -------------- | ----------------------------------------- |
+| `*.api.ts`     | Network requests                          |
+| `*.mappers.ts` | Backend/frontend translation              |
+| `*.types.ts`   | API response types and raw backend shapes |
+| `index.ts`     | Public surface                            |
+
+`*.types.ts` holds API-layer types only — raw backend shapes in backend conventions. Domain models
+live in `features/<feature>/models/` and are the `camelCase` application-facing types consumed by
+components. Mappers translate between the two at the service boundary. Raw backend shapes must not
+appear in component code.
+
+---
+
+## Hooks
+
+Hooks are organized by scope.
+
+**Cross-feature hooks** live in `src/hooks/`. Examples: `useDebounce`, `useColorScheme`,
+`useAppState`. (Note: there is no `useLocalStorage` or `useMediaQuery` on mobile — persistent
+storage goes through AsyncStorage / SecureStore in a service or provider, and responsive sizing uses
+`useWindowDimensions`.)
+
+**Feature-scoped hooks** live in `features/<feature>/hooks/`. Examples: `useEvent`, `useRsvp`.
+
+A hook used by only one feature stays in that feature. Promotion requires proven cross-feature
+reuse.
+
+---
+
+## Providers
+
+Context providers live in `src/providers/`. Providers own cross-cutting state and application-wide
+concerns (auth, theme, current user). They are mounted in `App.tsx`.
+
+Hooks that consume a provider's state live alongside the provider itself. Providers stay narrowly
+scoped — a provider accumulating unrelated concerns should be split.
+
+---
+
+## Styles and Tokens
+
+There are no global stylesheets and no CSS files. The web triad of `reset.css` / `globals.css` /
+`variables.css` does not exist on mobile.
+
+Shared design tokens live in `src/styles/tokens.ts` — a typed module exporting colors, spacing,
+radii, typography, and shadows. All other styling is co-located with its component via
+`StyleSheet.create`. See `mobile-styles` for the rules governing tokens versus component styles.
+
+---
+
+## Assets
+
+Bundled assets live under `assets/` at the project root:
+
+- `assets/fonts/` — font files loaded via `expo-font` (or `@expo-google-fonts`). Fonts are loaded
+  once during app bootstrap in `App.tsx`.
+- `assets/images/` — bundled images, plus the source images for the app icon and splash screen.
+
+The app icon, splash screen, name, and native plugin configuration are declared in the Expo config
+(`app.json` or `app.config.ts`) — not in code. Treat that config as part of the project structure: a
+single source of truth for app-level identity, referenced by path into `assets/`.
+
+---
+
+## Feature Folders
+
+A new feature folder is introduced only when the work owns:
+
+1. A distinct user-facing workflow.
+2. Distinct domain logic or models.
+
+A feature folder is **not** created for:
+
+- Generic dialogs or sheets
+- Shared primitives
+- Generic utilities
+- Isolated visual components lacking domain behavior
+
+Feature boundaries reflect product boundaries, not visual grouping.
+
+---
+
+## File Co-location
+
+Files stay co-located with the concern they support:
+
+```text
+EventCard/
+  EventCard.tsx
+  EventCard.styles.ts   # only when the StyleSheet grows large; otherwise keep it at the bottom of the .tsx
+  EventCard.types.ts
+  index.ts
+```
+
+There is no `.module.css` — styles are a `StyleSheet.create` block inside the component file by
+default, extracted to `EventCard.styles.ts` only when size justifies it. Additional files are
+introduced only when complexity justifies the split. Small components stay compact — a single `.tsx`
+is fine until it isn't.
+
+---
+
+## Import Rules
+
+Imports respect ownership boundaries:
+
+- Consumers import from public surfaces, not internal implementation files.
+- Within a feature, relative imports between sibling modules are acceptable.
+- Cross-feature imports reaching into internal implementation details are prohibited.
+- Type-only imports use `import type`.
+
+```ts
+import type { Event } from "@/features/events";
+```
+
+`import type` makes runtime dependencies explicit, improves clarity, and reduces accidental runtime
+coupling between modules.
+
+---
+
+## Folder Discipline
+
+Folders stay intentional and minimal:
+
+- Folders are not created before they contain files.
+- Nested component hierarchies stay shallow.
+- A `shared/` folder inside a feature must not exist. Cross-feature primitives belong in
+  `components/ui/`.
+- A `utils/` folder must not become a dumping ground.
+- Generic folders without ownership meaning are avoided.
+
+Utilities are grouped by responsibility, not pooled:
+
+```text
+lib/
+  date/
+  string/
+  format/
+```
+
+Folder depth emerges from real project complexity, not speculative organization.
+
+---
+
+## Common Mistakes to Avoid
+
+Recurring violations to watch for when adding files or reviewing structure:
+
+- A `router.tsx` route-config table created on mobile — navigation is a navigator tree under
+  `navigation/`, not a flat route object.
+- A `.tsx` file other than `App.tsx` placed directly under `src/` (screens belong in a feature;
+  primitives belong in `components/ui/`).
+- CSS files (`reset.css`, `globals.css`, `variables.css`) or `.module.css` files — there is no CSS
+  on mobile; tokens live in `styles/tokens.ts` and styles are co-located `StyleSheet` blocks.
+- A screen placed outside its feature, or a navigator containing screen content instead of just
+  wiring routes to screens.
+- A component promoted to `components/ui/` after a single use — promotion requires proven reuse and
+  domain-agnostic behavior.
+- A consumer importing from an internal implementation file
+  (`@/features/events/screens/EventScreen/EventScreen`) instead of the public surface
+  (`@/features/events`).
+- Fonts or images scattered through feature folders instead of `assets/`, or app icon/splash set in
+  code instead of the Expo config.
+- A component fetching from a backend directly instead of going through a service.
+- `snake_case` field names in a component file (the mapper at the service boundary is missing or
+  misplaced).
+- A `shared/` folder inside a feature, or a `utils/` dumping ground instead of `lib/date/`,
+  `lib/format/`, etc.
+- A type-only import without `import type`.
+- A provider accumulating unrelated cross-cutting concerns instead of being split.
+
+---
+
+## Predictable Navigation
+
+The structure makes ownership obvious. A future engineer or AI agent should be able to answer the
+following quickly:
+
+- Where does this code belong?
+- Which layer owns this concern?
+- Is this feature-specific or shared?
+- What is the public interface?
+- What dependencies are allowed?
+
+The structure optimizes for local reasoning and predictable refactoring, not maximal generic reuse.
+
+---
+
+## When to Consult the Related Standards
+
+- For component ownership, the boundary between shared primitives and feature components,
+  abstraction rules, and naming conventions: `frontend-philosophy`.
+- For unit choices, design tokens, variants, style keys, and platform-specific shadows:
+  `mobile-styles`.
+- For flex direction, shrinking, scroll ownership, safe areas, and constraint chains:
+  `mobile-layout`.

--- a/.claude/skills/mobile-styles/SKILL.md
+++ b/.claude/skills/mobile-styles/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: mobile-styles
+description:
+  Apply this repository's React Native styling conventions when writing or editing styles for mobile
+  components. Use whenever a `StyleSheet.create` block is being written or modified, when adding or
+  changing component styling, when introducing variants, when deciding what goes in a shared token
+  module versus a component, or when reviewing styles for compliance. Trigger this skill even when
+  the user phrases the request casually — "style this button", "add a new variant", "fix the spacing
+  on the card", "this component looks wrong" — because the conventions here govern unit choice,
+  design tokens, style keys, variants, platform-specific styling, and where styles are allowed to
+  live. Do not rely on general CSS or web knowledge for this codebase; React Native styling differs
+  from web CSS in several load-bearing ways (unitless dp not rem/px, StyleSheet objects not CSS
+  files, no selectors, style arrays for variants, split iOS/Android shadows). Applies to React
+  Native mobile components. Web has its own conventions.
+---
+
+# Mobile Styling Standards
+
+These are the styling conventions for React Native components in this repository. Follow them
+whenever writing or editing `StyleSheet` blocks, component styles, or shared style tokens.
+
+The styling philosophy is minimal, durable, predictable, and scalable — identical in spirit to the
+web standard. Styles should remain easy to reason about as the app grows. Favor composition,
+consistency, and predictable refactoring over short-term convenience.
+
+This skill covers visual presentation. Flex layout, shrinking, scroll ownership, and safe-area rules
+are in the `mobile-layout` skill. Component ownership and architectural boundaries are in
+`mobile-frontend-philosophy`.
+
+React Native has no CSS, no DOM, and no stylesheet cascade. There are no selectors, no inheritance
+(except limited text-style inheritance inside nested `<Text>`), and no media queries. A style is a
+plain object of camelCase properties applied directly to a component via its `style` prop. Most web
+CSS intuition about specificity and cascade does not apply.
+
+---
+
+## Styling System
+
+All component styles use `StyleSheet.create`. Each component defines its own co-located styles:
+
+```tsx
+import { StyleSheet, View, Text } from "react-native";
+
+export function EventCard() {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>...</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    /* ... */
+  },
+  title: {
+    /* ... */
+  },
+});
+```
+
+Because there is no global namespace to pollute, short structural keys (`card`, `title`, `content`,
+`actions`, `header`) are appropriate inside a component's `StyleSheet`.
+
+`StyleSheet.create` is preferred over inline object literals for all static styles: it keeps styles
+out of the render path, groups them in one readable block, and makes them reusable. Compose multiple
+styles with an array — later entries win:
+
+```tsx
+<View style={[styles.card, styles.cardElevated]} />
+```
+
+There is no equivalent of a "global stylesheet." Shared values live in the token module (below), not
+in a catch-all style file.
+
+---
+
+## Design Tokens
+
+Repeated visual values are extracted into design tokens in a single shared module (e.g.
+`styles/tokens.ts`), exported as typed objects. Token categories:
+
+- Colors
+- Spacing
+- Radii
+- Typography (size, weight, line height)
+- Shadows (see the platform note below)
+- Z-index layers
+- Animation durations
+
+```ts
+export const spacing = { xs: 4, sm: 8, md: 16, lg: 24, xl: 32 } as const;
+export const colors = {
+  /* ... */
+} as const;
+```
+
+A recurring visual value in component styles indicates a missing token. Magic numbers do not belong
+in component `StyleSheet` blocks. This is the mobile analog of the web `variables.css` rule — same
+principle, expressed as a typed module instead of CSS custom properties.
+
+---
+
+## Units: unitless dp, not rem or px
+
+React Native has no `rem` and no `px`. Numeric length values are **density-independent pixels (dp)**
+— plain unitless numbers that React Native scales per device automatically:
+
+```ts
+{ padding: 16, borderRadius: 12, marginTop: 8 }
+```
+
+There is no conversion math and no base-16 calculation. Write the intended dp value directly.
+
+Specifics:
+
+- **Numbers** are dp. Use them for nearly everything.
+- **Percentage strings** (`"50%"`) are permitted where a proportion of the parent is genuinely
+  intended.
+- **Hairline borders**: use `StyleSheet.hairlineWidth` for the thinnest device-appropriate line
+  rather than a hardcoded `1`.
+- Never append `"px"` to a value — it is invalid in React Native and will throw or be ignored.
+
+**Font scaling is the mobile analog of the web `rem` rationale.** On the web, `rem` exists so
+layouts respect the user's font-size preference. On mobile, `<Text>` respects the OS Dynamic Type /
+font scaling setting by default. Do not disable this with `allowFontScaling={false}` except for
+genuinely fixed-size UI (e.g. a numeric badge that must not reflow), and document the reason when
+you do.
+
+---
+
+## Inline and Dynamic Styles
+
+Inline style objects are reserved for genuinely dynamic values that cannot be expressed as a static
+style:
+
+- Runtime positioning or sizing values
+- Dynamically computed transforms
+- Animation values (Animated / Reanimated)
+- Values derived from props or index (e.g. a staggered delay)
+
+```tsx
+<View style={[styles.row, { transform: [{ translateX: offset }] }]} />
+```
+
+Static, reusable values always belong in `StyleSheet.create` and are composed via the style array —
+not inlined. An inline object for a static value is a missed token or missed style key.
+
+---
+
+## Variants
+
+Stable visual modes are expressed through variants, applied with the style array — not scattered
+overrides or ad-hoc conditionals sprinkled through markup.
+
+```tsx
+<Button variant="primary" />
+<Button variant="secondary" />
+```
+
+```tsx
+const styles = StyleSheet.create({
+  button: {
+    /* base */
+  },
+  buttonPrimary: {
+    /* primary variant */
+  },
+  buttonSecondary: {
+    /* secondary variant */
+  },
+});
+
+const variantStyle = {
+  primary: styles.buttonPrimary,
+  secondary: styles.buttonSecondary,
+}[variant];
+
+<Pressable style={[styles.button, variantStyle]} />;
+```
+
+A reusable primitive exposes only a small number of stable variants. A primitive requiring many
+unrelated variants likely owns too much responsibility and should be split.
+
+---
+
+## File Placement
+
+Styles are co-located with their component:
+
+```text
+EventCard/
+  EventCard.tsx        // StyleSheet defined here, at the bottom of the file
+```
+
+A component's `StyleSheet` contains styles for that component only. Styles for sibling or child
+components live in those components' own files. Keeping the `StyleSheet.create` block at the bottom
+of the component file is the default; extract to a separate `EventCard.styles.ts` only when the
+block grows large enough to hurt readability.
+
+---
+
+## Styling Placement
+
+Styling stays co-located with the concern it supports.
+
+- Reusable primitives may contain only domain-agnostic styling.
+- Feature-specific presentation belongs in feature components.
+- Feature-specific styling does not appear inside shared primitives.
+
+A feature-specific rule appearing inside a shared primitive is a leak. Move it to the feature
+component.
+
+---
+
+## Style Keys and Naming
+
+Style object keys use camelCase. Short and structural is fine — keys are scoped to the component's
+own `StyleSheet`, so there is no namespacing concern.
+
+```ts
+const styles = StyleSheet.create({
+  panel: {
+    /* ... */
+  },
+  header: {
+    /* ... */
+  },
+  content: {
+    /* ... */
+  },
+});
+```
+
+Variants and modifiers use camelCase suffixes on the base key: `button`, `buttonPrimary`,
+`buttonDisabled`.
+
+**BEM and class-name conventions do not apply** — there are no class names in React Native. These
+are object keys, not CSS classes.
+
+---
+
+## No Selectors — Compose Through Structure
+
+React Native has no selectors at all. You cannot target a descendant, a sibling, or a state from
+within a style. There is nothing to keep "shallow" because the concept does not exist.
+
+The principle the web skill expresses through shallow selectors still holds in a different form:
+**style each element directly, and compose through component structure and variants — never reach
+into a child's internals.** A parent does not style its child; the child owns its own styles and
+exposes variants or props. Coupling presentation across component boundaries is the failure to
+avoid.
+
+Limited exception: text styles (color, font, weight) inherit down through nested `<Text>` elements.
+This is the only inheritance React Native provides; rely on it for text only.
+
+---
+
+## Shadows and Platform Differences
+
+Shadows are not a single cross-platform property. They must be set per platform:
+
+- **iOS**: `shadowColor`, `shadowOffset`, `shadowOpacity`, `shadowRadius`.
+- **Android**: `elevation` (a single number; Android renders its own shadow from it).
+
+Define shadow tokens that bundle both so callers get a correct shadow on both platforms from one
+reference:
+
+```ts
+export const shadows = {
+  card: {
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+} as const;
+```
+
+Other properties also differ by platform (e.g. `fontFamily` weights, `letterSpacing` behavior). When
+a value must differ, use `Platform.select({ ios, android })` rather than branching in render.
+
+---
+
+## Minimalism
+
+Every style declaration must do work. Remove declarations that are not actively required.
+
+The principles:
+
+- Repeated values become tokens.
+- Compose through style arrays and variants, not conditional override soup.
+- Static styles live in `StyleSheet.create`; only dynamic values go inline.
+- Layout bugs are fixed at the source (see the `mobile-layout` skill).
+- Generic abstractions are introduced cautiously.
+
+Styles must stay predictable under refactoring. A future engineer or AI agent should be able to
+modify styling confidently without unintended side effects.
+
+---
+
+## Common Failures
+
+### Magic numbers in component styles
+
+Hardcoded values instead of tokens → inconsistent values, brittle refactoring.
+
+### Feature-specific styles in shared primitives
+
+Domain styling inside `components/ui/` → coupled primitives, leaking feature concerns.
+
+### Hardcoded `"px"` or invented units
+
+Appending `"px"` or assuming `rem` → invalid in React Native; values throw or are ignored.
+
+### Inline objects replacing reusable styles
+
+Inline `style={{}}` for static values → values can't be tokenized, reused, or kept out of render.
+
+### Variants expressed as scattered conditionals
+
+One-off inline conditionals instead of defined variants → fragile, inconsistent visual treatment.
+
+### Single-platform shadows
+
+`elevation` only (invisible on iOS) or `shadow*` only (invisible on Android) → shadow missing on
+half your users' devices.
+
+---
+
+## Common Mistakes to Avoid
+
+- Using `rem`/`px`, or appending any unit string to a numeric value.
+- Hardcoded color, spacing, radius, or duration values that should reference a token.
+- Inline `style` objects used for static values that should be a keyed style.
+- A shared primitive accumulating feature-specific styling.
+- A primitive that has grown five-plus unrelated variants — split it instead of adding more.
+- Setting only `elevation` or only the iOS `shadow*` props.
+- Disabling `allowFontScaling` without a documented reason.
+- Attempting to style a child from a parent instead of letting the child own its styles.
+
+---
+
+## When to Consult the Related Standards
+
+- For flex direction, shrinking, scroll ownership, safe areas, and the `flexShrink` / `flex: 1`
+  rules that govern sizing and overflow: `mobile-layout`.
+- For component design, state ownership, the `style` prop convention, and when to split a primitive:
+  `mobile-frontend-philosophy`.
+- For where files live and the boundary between `components/ui/` and `features/`:
+  `mobile-project-structure`.

--- a/docs/adrs/0005-frontend-technologies.md
+++ b/docs/adrs/0005-frontend-technologies.md
@@ -5,7 +5,7 @@ status: accepted
 owners: ["@julian-cardone"]
 last_reviewed: 2026-06-02
 related: []
-tags: [frontend, mobile, react-native, expo, navigation]
+tags: [architecture, tooling]
 ---
 
 # ADR-0005: Frontend Framework, Dev Toolchain, and Navigation

--- a/docs/adrs/0005-frontend-technologies.md
+++ b/docs/adrs/0005-frontend-technologies.md
@@ -1,0 +1,108 @@
+---
+title: "ADR-0005: Frontend Framework, Dev Toolchain, and Navigation"
+doc_type: adr
+status: accepted
+owners: ["@julian-cardone"]
+last_reviewed: 2026-06-02
+related: []
+tags: [frontend, mobile, react-native, expo, navigation]
+---
+
+# ADR-0005: Frontend Framework, Dev Toolchain, and Navigation
+
+## Context
+
+Placecard is a mobile-first social app targeting iOS and Android. The engineering team has an
+existing React JS background but no prior React Native experience.
+
+The decision covers three tightly coupled choices:
+
+- **UI framework**: what technology renders the mobile app.
+- **Dev toolchain**: how the app is built, run, and previewed during development.
+- **Navigation**: how screens, tabs, and modals are managed at runtime.
+
+These choices are foundational — they shape every screen, component, and developer workflow from day
+one. Reversing any of them later would require a near-total rewrite.
+
+**Constraints:**
+
+- Small team with no dedicated mobile engineers.
+- React JS familiarity; no prior React Native experience.
+- V1 is NYC invite-only beta — no need to optimize for scale or distribution complexity yet.
+- iOS- and Android-specific native build tooling (Xcode, Android Studio) is explicitly out of scope
+  for the initial development phase.
+
+**Alternatives considered:**
+
+- **Flutter**: strong cross-platform story, but requires learning Dart and abandons the team's
+  existing React and JavaScript knowledge entirely. Rejected.
+- **Ionic / Capacitor**: web-based; renders in a WebView rather than native components. Acceptable
+  for some use cases but produces a noticeably less native feel for gesture-heavy UIs like swipe
+  stacks and tab navigation. Rejected.
+- **Bare React Native (without Expo)**: gives full control over native code but requires Xcode and
+  Android Studio from day one, adding significant setup overhead and platform-specific complexity
+  before any product work is done. Deferred — this is the likely path for production builds but is
+  not appropriate for the current phase.
+- **React Navigation alternatives (React Native Navigation by Wix)**: closer to native navigation
+  primitives but requires native build tooling and is more complex to configure. Not compatible with
+  Expo Go. Rejected for V1.
+
+## Decision
+
+**React Native** is the UI framework for the Placecard mobile app.
+
+**Expo (managed workflow via Expo Go)** is the development toolchain for the current phase. Expo Go
+— a companion app installed on a physical device — serves as the primary live preview environment.
+This eliminates the need for Xcode or Android Studio during active development. Native build tooling
+will be introduced when App Store and Play Store distribution becomes necessary.
+
+**React Navigation** is the navigation library. It handles the five-tab bottom navigation (Discover,
+Explore, Add a Plan, Messages, Profile), stack navigators for screen-level transitions, and modal
+presentation. React Navigation is the de facto standard in the React Native ecosystem and is fully
+compatible with Expo Go.
+
+Styling uses React Native's built-in `StyleSheet` API. No third-party CSS or styling library is
+introduced unless a concrete gap is identified.
+
+## Consequences
+
+### Positives
+
+- React JS knowledge transfers directly — components, hooks, props, and state work identically. The
+  learning surface is limited to React Native's rendering primitives and layout model.
+- Expo Go enables instant live preview on a real physical device via QR code, with hot reload. No
+  Xcode, no Android Studio, no emulator setup required.
+- React Navigation is mature, well-documented, and widely used. Solutions to common problems are
+  readily available.
+- `StyleSheet` is sufficient for V1 and keeps the dependency surface small.
+- Expo's managed workflow handles native dependencies, OTA updates, and build configuration
+  automatically for the current phase.
+
+### Negatives
+
+- Expo Go imposes constraints on which native modules can be used. Any feature requiring a native
+  module not included in Expo's managed runtime will require ejecting to a bare workflow or using
+  Expo's EAS Build service.
+- `StyleSheet` has meaningful differences from CSS: no cascade, no shorthand properties, no
+  `position: fixed`, and split shadow APIs across iOS and Android. These require adjustment.
+- Ejecting from Expo's managed workflow later — when App Store distribution is needed — will require
+  native build tooling setup at that point.
+- React Navigation adds abstraction over native navigation; in edge cases, behavior may not match
+  platform-native navigation exactly.
+
+### Out of Scope
+
+- Native build configuration (Xcode, Android Studio, EAS Build) is not addressed by this ADR.
+- App Store and Play Store distribution strategy is not addressed by this ADR.
+- The decision of whether to eject from Expo's managed workflow for production builds is not made
+  here.
+- Third-party styling libraries (e.g., NativeWind, Tamagui) are not evaluated here. If `StyleSheet`
+  proves insufficient, a separate ADR should be written.
+- Web support via React Native Web is not in scope for V1.
+
+## Notes
+
+Expo Go is appropriate for the current development phase. When the team is ready to target
+production distribution, the path forward is Expo's EAS Build service or a full eject to a bare
+React Native workflow — both are well-supported migration paths. That decision should be captured in
+a separate ADR at that time.


### PR DESCRIPTION
## Summary

This PR establishes the frontend technology stack for Placecard and defines mobile development skills needed for the project. It includes:

- ADR 0005 documenting frontend technology choices (React, React Native, supporting tools)
- Three new mobile development skills for React Native: mobile-layout, mobile-project-structure, and mobile-styles
- Updates to the frontend-philosophy skill to cover both web and mobile contexts

## Changes

- Created `docs/adrs/0005-frontend-technologies.md` — Architecture Decision Record for frontend technology selection
- Created `.claude/skills/mobile-layout/SKILL.md` — React Native flex layout conventions
- Created `.claude/skills/mobile-project-structure/SKILL.md` — Mobile project structure patterns
- Created `.claude/skills/mobile-styles/SKILL.md` — Mobile styling conventions
- Updated `.claude/skills/frontend-philosophy/SKILL.md` — Extended to cover React Native

## Related

Closes #54

## Documentation Updates

The ADR documents technology choices. Mobile skills extend the existing skill framework for native development.

## ADR Requirement

ADR 0005 was created to document the frontend technology decisions.

## Definition of Done

- ADR explains the decision, constraints, and rationale
- Mobile skills are consistent with existing skill patterns
- All documentation follows standards from `docs/standards/documentation.md`
- Skills are integrated into the system