### PR TITLE
chore(infra): Fix Dev Environment: Expo, Import Autofill, and Config QoL

### DIFF
--- a/.claude/commands/merge-worktree.md
+++ b/.claude/commands/merge-worktree.md
@@ -1,0 +1,25 @@
+---
+description: Commit, merge, and clean up a worktree branch
+argument-hint: [worktree-name] [target-branch]
+allowed-tools: Bash(git:*), Bash(bash scripts/worktree-merge.sh:*)
+model: claude-haiku-4-5-20251001
+---
+
+Merge the worktree `$1` into branch `$2`, then clean it up.
+
+Steps:
+
+1. Inspect pending changes:
+   - `git -C .claude/worktrees/$1 status --porcelain`
+   - `git -C .claude/worktrees/$1 diff HEAD`
+2. If there are uncommitted changes, write a conventional-commit message (`feat:`, `fix:`, `docs:`,
+   `chore:`, `refactor:`) summarizing them.
+3. Run the merge script:
+   - With changes: `bash scripts/worktree-merge.sh $1 $2 "<commit message>"`
+   - No changes: `bash scripts/worktree-merge.sh $1 $2`
+4. If the script exits reporting a merge conflict, do not force anything. Resolve the conflicted
+   files, commit the merge, then run the cleanup manually:
+   - `git worktree remove .claude/worktrees/$1`
+   - `git branch -d worktree-$1`
+   - `git worktree prune`
+5. Report exactly what was committed, merged, and removed.

--- a/.claude/commands/merge-worktree.md
+++ b/.claude/commands/merge-worktree.md
@@ -17,9 +17,23 @@ Steps:
 3. Run the merge script:
    - With changes: `bash scripts/worktree-merge.sh $1 $2 "<commit message>"`
    - No changes: `bash scripts/worktree-merge.sh $1 $2`
-4. If the script exits reporting a merge conflict, do not force anything. Resolve the conflicted
-   files, commit the merge, then run the cleanup manually:
-   - `git worktree remove .claude/worktrees/$1`
-   - `git branch -d worktree-$1`
-   - `git worktree prune`
+4. If the script exits non-zero due to a merge conflict, **STOP IMMEDIATELY**. Do not attempt to
+   resolve the conflict, edit any files, or run any further git commands. Report the conflict to the
+   user with the exact output from the script, then output these manual resolution steps verbatim
+   and wait:
+
+   ```
+   MERGE CONFLICT — manual resolution required.
+
+   1. Resolve the conflicted files in your editor.
+   2. Stage the resolved files: git add <files>
+   3. Complete the merge: git merge --continue
+   4. Clean up the worktree:
+      git worktree remove .claude/worktrees/$1
+      git branch -d worktree-$1
+      git worktree prune
+   ```
+
+   Do not proceed or offer further assistance until the user reports the conflict is resolved.
+
 5. Report exactly what was committed, merged, and removed.

--- a/.claude/commands/merge-worktree.md
+++ b/.claude/commands/merge-worktree.md
@@ -22,7 +22,7 @@ Steps:
    user with the exact output from the script, then output these manual resolution steps verbatim
    and wait:
 
-   ```
+   ```text
    MERGE CONFLICT — manual resolution required.
 
    1. Resolve the conflicted files in your editor.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -18,11 +18,10 @@ Copy all `type:*` and `scope:*` labels from the issue directly onto the PR.
 
 Also add these based on `git diff main...HEAD --name-only`:
 
-| If diff contains         | Add label        |
-| ------------------------ | ---------------- |
-| `package.json`/lockfile  | `dependencies`   |
-| `.github/workflows/`     | `github_actions` |
-| `.js`/`.ts`/`.tsx` files | `javascript`     |
+| If diff contains        | Add label        |
+| ----------------------- | ---------------- |
+| `package.json`/lockfile | `dependencies`   |
+| `.github/workflows/`    | `github_actions` |
 
 ## Title
 

--- a/.claude/skills/mobile-project-structure/SKILL.md
+++ b/.claude/skills/mobile-project-structure/SKILL.md
@@ -23,7 +23,7 @@ rules live in `mobile-styles`. Flex, scroll, keyboard, and safe-area rules live 
 ## Reference Structure
 
 ```text
-app.json or app.config.ts          # Expo config: name, icon, splash, plugins
+app.config.ts                      # Expo config: name, icon, splash, plugins, env-specific overrides
 index.js                          # registerRootComponent(App)
 assets/
   fonts/                          # bundled fonts if not using @expo-google-fonts

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,9 @@
 {
-  "recommendations": ["GitHub.copilot", "GitHub.copilot-chat", "anthropics.claude-code"]
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "github.copilot",
+    "github.copilot-chat",
+    "anthropics.claude-code"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,36 @@
 {
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
+
+  "eslint.enable": true,
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ],
+
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "always",
+    "source.organizeImports": "never"
+  },
+
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   }

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,0 +1,11 @@
+import type { ConfigContext, ExpoConfig } from "expo/config";
+
+const IS_PROD = process.env.APP_ENV === "production";
+
+export default ({ config }: ConfigContext): ExpoConfig => ({
+  ...config,
+  name: IS_PROD ? "Placecard" : "Placecard Dev",
+  slug: "placecard",
+  version: "1.0.0",
+  orientation: "portrait",
+});

--- a/app/app.json
+++ b/app/app.json
@@ -1,8 +1,0 @@
-{
-  "expo": {
-    "name": "placecard",
-    "slug": "placecard",
-    "version": "1.0.0",
-    "orientation": "portrait"
-  }
-}

--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -1,26 +1,75 @@
 import eslint from "@eslint/js";
-import tseslint from "typescript-eslint";
 import reactPlugin from "eslint-plugin-react";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
+import simpleImportSortPlugin from "eslint-plugin-simple-import-sort";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["node_modules/", ".expo/", "dist/", "build/"] },
+  {
+    ignores: ["node_modules/", ".expo/", "dist/", "build/"],
+  },
+
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
+
   {
     plugins: {
       react: reactPlugin,
       "react-hooks": reactHooksPlugin,
+      "simple-import-sort": simpleImportSortPlugin,
     },
-    settings: { react: { version: "detect" } },
+
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
+
     rules: {
       ...reactPlugin.configs.recommended.rules,
       ...reactHooksPlugin.configs.recommended.rules,
+
       "react/react-in-jsx-scope": "off",
       "react/prop-types": "off",
+
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        {
+          prefer: "type-imports",
+          fixStyle: "separate-type-imports",
+        },
+      ],
+
+      "simple-import-sort/imports": [
+        "error",
+        {
+          groups: [
+            // Side effect imports.
+            ["^\\u0000"],
+
+            // React, React Native, and Expo.
+            ["^react$", "^react-native$", "^expo", "^@expo"],
+
+            // Third-party packages.
+            ["^@?\\w"],
+
+            // App absolute imports.
+            ["^@/"],
+
+            // Parent imports.
+            ["^\\.\\.(?!/?$)", "^\\.\\./?$"],
+
+            // Same-folder imports.
+            ["^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"],
+          ],
+        },
+      ],
+
+      "simple-import-sort/exports": "error",
     },
   },
+
   {
     files: ["*.config.{js,cjs}", "babel.config.js"],
     languageOptions: {

--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -67,6 +67,7 @@ export default tseslint.config(
       ],
 
       "simple-import-sort/exports": "error",
+      "no-duplicate-imports": "error",
     },
   },
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -30,6 +30,7 @@
         "eslint": "^9.0.0",
         "eslint-plugin-react": "^7.0.0",
         "eslint-plugin-react-hooks": "^5.0.0",
+        "eslint-plugin-simple-import-sort": "^13.0.0",
         "globals": "^14.0.0",
         "prettier": "^3.0.0",
         "typescript": "~5.9.2",
@@ -5577,6 +5578,16 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-13.0.0.tgz",
+      "integrity": "sha512-McAc+/Nlvcg4byY/CABGH8kqnefWBj8s3JA2okEtz8ixbECQgU46p0HkTUKa4YS7wvgGceimlc34p1nXqbWqtA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -6463,7 +6474,9 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "os": ["darwin"],
+      "os": [
+        "darwin"
+      ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -7870,10 +7883,14 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "license": "MPL-2.0",
       "optional": true,
-      "os": ["android"],
+      "os": [
+        "android"
+      ],
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7886,10 +7903,14 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "license": "MPL-2.0",
       "optional": true,
-      "os": ["darwin"],
+      "os": [
+        "darwin"
+      ],
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7902,10 +7923,14 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "license": "MPL-2.0",
       "optional": true,
-      "os": ["darwin"],
+      "os": [
+        "darwin"
+      ],
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7918,10 +7943,14 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "license": "MPL-2.0",
       "optional": true,
-      "os": ["freebsd"],
+      "os": [
+        "freebsd"
+      ],
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7934,10 +7963,14 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": ["arm"],
+      "cpu": [
+        "arm"
+      ],
       "license": "MPL-2.0",
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7950,11 +7983,17 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": ["arm64"],
-      "libc": ["glibc"],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7967,11 +8006,17 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": ["arm64"],
-      "libc": ["musl"],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7984,11 +8029,17 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": ["x64"],
-      "libc": ["glibc"],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8001,11 +8052,17 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": ["x64"],
-      "libc": ["musl"],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8018,10 +8075,14 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "license": "MPL-2.0",
       "optional": true,
-      "os": ["win32"],
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8034,10 +8095,14 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "license": "MPL-2.0",
       "optional": true,
-      "os": ["win32"],
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/app/package.json
+++ b/app/package.json
@@ -31,9 +31,9 @@
     "typescript-eslint": "^8.0.0"
   },
   "scripts": {
-    "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "start": "EXPO_NO_DEPENDENCY_VALIDATION=1 expo start",
+    "android": "EXPO_NO_DEPENDENCY_VALIDATION=1 expo start --android",
+    "ios": "EXPO_NO_DEPENDENCY_VALIDATION=1 expo start --ios",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json}\"",

--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,7 @@
     "eslint": "^9.0.0",
     "eslint-plugin-react": "^7.0.0",
     "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-simple-import-sort": "^13.0.0",
     "globals": "^14.0.0",
     "prettier": "^3.0.0",
     "typescript": "~5.9.2",

--- a/app/src/components/branding/Wordmark/Wordmark.tsx
+++ b/app/src/components/branding/Wordmark/Wordmark.tsx
@@ -1,7 +1,8 @@
 import { StyleSheet, Text } from "react-native";
 
-import { colors, fontFamily, fontSize } from "@/styles/tokens";
 import type { StyleProp, TextStyle } from "react-native";
+
+import { colors, fontFamily, fontSize } from "@/styles/tokens";
 
 type WordmarkProps = {
   /** `splash` is the large centered brand moment; `compact` sits at the top of a screen. */

--- a/app/src/components/branding/Wordmark/Wordmark.tsx
+++ b/app/src/components/branding/Wordmark/Wordmark.tsx
@@ -1,6 +1,4 @@
-import { StyleSheet, Text } from "react-native";
-
-import type { StyleProp, TextStyle } from "react-native";
+import { type StyleProp, StyleSheet, Text, type TextStyle } from "react-native";
 
 import { colors, fontFamily, fontSize } from "@/styles/tokens";
 

--- a/app/src/components/ui/AppText/AppText.tsx
+++ b/app/src/components/ui/AppText/AppText.tsx
@@ -1,4 +1,6 @@
-import { StyleSheet, Text, TextProps } from "react-native";
+import { StyleSheet, Text } from "react-native";
+
+import type { TextProps } from "react-native";
 
 import { colors, fontFamily, fontSize, lineHeight } from "@/styles/tokens";
 

--- a/app/src/components/ui/AppText/AppText.tsx
+++ b/app/src/components/ui/AppText/AppText.tsx
@@ -1,6 +1,4 @@
-import { StyleSheet, Text } from "react-native";
-
-import type { TextProps } from "react-native";
+import { StyleSheet, Text, type TextProps } from "react-native";
 
 import { colors, fontFamily, fontSize, lineHeight } from "@/styles/tokens";
 

--- a/app/src/components/ui/Button/Button.tsx
+++ b/app/src/components/ui/Button/Button.tsx
@@ -1,5 +1,5 @@
+import { Pressable, type StyleProp, StyleSheet, Text, type ViewStyle } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
-import { Pressable, StyleSheet, Text, type StyleProp, type ViewStyle } from "react-native";
 
 import { colors, fontFamily, fontSize, radii, shadows, spacing } from "@/styles/tokens";
 

--- a/app/src/components/ui/Screen/Screen.tsx
+++ b/app/src/components/ui/Screen/Screen.tsx
@@ -1,13 +1,14 @@
-import type { PropsWithChildren } from "react";
 import {
   KeyboardAvoidingView,
   Platform,
   ScrollView,
+  type StyleProp,
   StyleSheet,
   View,
-  type StyleProp,
   type ViewStyle,
 } from "react-native";
+
+import type { PropsWithChildren } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { colors, spacing } from "@/styles/tokens";

--- a/app/src/components/ui/index.ts
+++ b/app/src/components/ui/index.ts
@@ -1,4 +1,4 @@
-export { Button } from "./Button";
 export { Wordmark } from "../branding/Wordmark";
-export { Screen } from "./Screen";
 export { AppText } from "./AppText";
+export { Button } from "./Button";
+export { Screen } from "./Screen";

--- a/app/src/features/onboarding/components/TermsFootnote.tsx
+++ b/app/src/features/onboarding/components/TermsFootnote.tsx
@@ -1,7 +1,7 @@
 import { Linking, StyleSheet, Text } from "react-native";
 
-import { colors, fontFamily, fontSize, lineHeight } from "@/styles/tokens";
 import { externalLinks } from "@/constants/links";
+import { colors, fontFamily, fontSize, lineHeight } from "@/styles/tokens";
 
 const handleTermsPress = () => {
   void Linking.openURL(externalLinks.terms);

--- a/app/src/features/onboarding/index.ts
+++ b/app/src/features/onboarding/index.ts
@@ -1,3 +1,3 @@
-export { SplashScreen } from "./screens/SplashScreen";
 export { PhoneEntryScreen } from "./screens/PhoneEntryScreen";
+export { SplashScreen } from "./screens/SplashScreen";
 export { VerifyScreen } from "./screens/VerifyScreen";

--- a/app/src/features/onboarding/screens/PhoneEntryScreen.tsx
+++ b/app/src/features/onboarding/screens/PhoneEntryScreen.tsx
@@ -1,14 +1,15 @@
-import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+
 import { Button, Screen, Wordmark } from "@/components/ui";
+import { AppText } from "@/components/ui";
 import type { RootStackParamList } from "@/navigation/types";
 import { colors, spacing } from "@/styles/tokens";
 
 import { PhoneNumberInput } from "../components/PhoneNumberInput";
 import { TermsFootnote } from "../components/TermsFootnote";
-import { AppText } from "@/components/ui";
 
 type Props = NativeStackScreenProps<RootStackParamList, "PhoneEntry">;
 

--- a/app/src/features/onboarding/screens/PhoneEntryScreen.tsx
+++ b/app/src/features/onboarding/screens/PhoneEntryScreen.tsx
@@ -3,8 +3,7 @@ import { StyleSheet, View } from "react-native";
 
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 
-import { Button, Screen, Wordmark } from "@/components/ui";
-import { AppText } from "@/components/ui";
+import { AppText, Button, Screen, Wordmark } from "@/components/ui";
 import type { RootStackParamList } from "@/navigation/types";
 import { colors, spacing } from "@/styles/tokens";
 

--- a/app/src/features/onboarding/screens/SplashScreen.tsx
+++ b/app/src/features/onboarding/screens/SplashScreen.tsx
@@ -1,6 +1,7 @@
-import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useEffect, useRef } from "react";
 import { Animated, StyleSheet } from "react-native";
+
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 import { Screen, Wordmark } from "@/components/ui";
 import type { RootStackParamList } from "@/navigation/types";

--- a/app/src/features/onboarding/screens/VerifyScreen.tsx
+++ b/app/src/features/onboarding/screens/VerifyScreen.tsx
@@ -3,8 +3,7 @@ import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 
-import { Button, Screen } from "@/components/ui";
-import { AppText } from "@/components/ui";
+import { AppText, Button, Screen } from "@/components/ui";
 import type { RootStackParamList } from "@/navigation/types";
 import { colors, fontFamily, fontSize, spacing } from "@/styles/tokens";
 

--- a/app/src/features/onboarding/screens/VerifyScreen.tsx
+++ b/app/src/features/onboarding/screens/VerifyScreen.tsx
@@ -1,13 +1,14 @@
-import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useState } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+
 import { Button, Screen } from "@/components/ui";
+import { AppText } from "@/components/ui";
 import type { RootStackParamList } from "@/navigation/types";
 import { colors, fontFamily, fontSize, spacing } from "@/styles/tokens";
 
 import { CodeInput } from "../components/CodeInput";
-import { AppText } from "@/components/ui";
 
 type Props = NativeStackScreenProps<RootStackParamList, "Verify">;
 

--- a/app/src/hooks/useAppBootstrap.ts
+++ b/app/src/hooks/useAppBootstrap.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import * as SplashScreen from "expo-splash-screen";
 import {
   Nunito_400Regular,
   Nunito_600SemiBold,
@@ -7,7 +8,6 @@ import {
   Nunito_900Black,
   useFonts,
 } from "@expo-google-fonts/nunito";
-import * as SplashScreen from "expo-splash-screen";
 
 // Must run before the component tree mounts so the native splash stays visible during init.
 void SplashScreen.preventAutoHideAsync();

--- a/app/src/navigation/DevBar.tsx
+++ b/app/src/navigation/DevBar.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+
 import type { NavigationContainerRef } from "@react-navigation/native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import type { RootStackParamList } from "./types";
 

--- a/app/src/navigation/RootNavigator.tsx
+++ b/app/src/navigation/RootNavigator.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
 import { PhoneEntryScreen, SplashScreen, VerifyScreen } from "@/features/onboarding";
+
 import type { RootStackParamList } from "./types";
 
 const Stack = createNativeStackNavigator<RootStackParamList>();

--- a/app/src/providers/AppProviders.tsx
+++ b/app/src/providers/AppProviders.tsx
@@ -1,4 +1,4 @@
-import { createNavigationContainerRef,NavigationContainer } from "@react-navigation/native";
+import { createNavigationContainerRef, NavigationContainer } from "@react-navigation/native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 

--- a/app/src/providers/AppProviders.tsx
+++ b/app/src/providers/AppProviders.tsx
@@ -1,4 +1,4 @@
-import { NavigationContainer, createNavigationContainerRef } from "@react-navigation/native";
+import { createNavigationContainerRef,NavigationContainer } from "@react-navigation/native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 

--- a/docs/process/git-workflow.md
+++ b/docs/process/git-workflow.md
@@ -172,7 +172,7 @@ When two worktrees both target the same branch, merge them sequentially:
 
 The second merge needs the first committed to reconcile both sets of changes correctly.
 
-**Merge conflicts**
+### Merge conflicts
 
 The script aborts before cleanup when a conflict occurs. Resolve the conflicted files, commit the
 merge, then clean up manually:

--- a/docs/process/git-workflow.md
+++ b/docs/process/git-workflow.md
@@ -126,8 +126,8 @@ Spin up a worktree called feat-user-auth, implement user authentication in src/a
 and when done notify me that the worktree is ready to merge.
 ```
 
-Claude Code will complete the work and stop, leaving the merge as a deliberate human step. Do not
-instruct a session to merge autonomously — that step warrants human review.
+Claude Code completes the work and stops, leaving the merge as a deliberate human step. Do not
+instruct a session to merge autonomously — that step requires human review.
 
 ### Scope discipline
 

--- a/docs/process/git-workflow.md
+++ b/docs/process/git-workflow.md
@@ -119,6 +119,16 @@ Naming rules: lowercase, hyphen-separated, a type prefix followed by a short des
 four words. The prefix matches the intended pull request title so the branch purpose is unambiguous
 across sessions.
 
+A session can also be given the full task in the opening prompt and run autonomously:
+
+```text
+Spin up a worktree called feat-user-auth, implement user authentication in src/auth/,
+and when done notify me that the worktree is ready to merge.
+```
+
+Claude Code will complete the work and stop, leaving the merge as a deliberate human step. Do not
+instruct a session to merge autonomously — that step warrants human review.
+
 ### Scope discipline
 
 Each session is given an explicit scope at start: the directories or files it is permitted to read
@@ -129,29 +139,73 @@ If a session encounters build errors in files it did not edit, it must not attem
 correct response is to wait and retry — another session is likely mid-edit. Cascading fix attempts
 across sessions are the primary cause of parallel failures.
 
-### Ownership and merging
+### Merging
 
-Each worktree is one pull request with one owner. The session assigned to a branch owns it from
-start to finish. Merging is a separate orchestration step and is never performed by a running
-session. A session must not merge, rebase, or pull from other worktree branches while active.
+Each worktree is one pull request with one owner. A running session must not merge, rebase, or pull
+from other worktree branches — merging is always a separate orchestration step performed after the
+session completes.
 
-### Cleanup
-
-When a session exits cleanly with no uncommitted changes and no new commits, the worktree and its
-branch are removed automatically. When changes exist, Claude Code prompts to keep or remove.
-Worktrees created with `--worktree` are not removed by the automatic sweep.
-
-Review and prune stale worktrees periodically:
+Use the `/merge-worktree` slash command as the default:
 
 ```text
-git worktree list
-git worktree remove <path>
+/merge-worktree <name> <target-branch>
+```
+
+The command reads the diff, generates a conventional-commit message, calls
+`scripts/worktree-merge.sh`, and reports what was merged and cleaned up. When the commit message is
+already known, call the script directly to avoid the token cost:
+
+```text
+bash scripts/worktree-merge.sh <name> <target-branch> "<commit message>"
+```
+
+The script commits any pending changes in the worktree, merges into the target, and removes the
+worktree and branch on success. It will not proceed if the main working tree is dirty, and it will
+not delete a branch that has not been fully merged.
+
+When two worktrees both target the same branch, merge them sequentially:
+
+```text
+/merge-worktree feat-user-auth main
+/merge-worktree feat-api-endpoints main
+```
+
+The second merge needs the first committed to reconcile both sets of changes correctly.
+
+**Merge conflicts**
+
+The script aborts before cleanup when a conflict occurs. Resolve the conflicted files, commit the
+merge, then clean up manually:
+
+```text
+git worktree remove .claude/worktrees/<name>
+git branch -d worktree-<name>
 git worktree prune
 ```
 
+A branch checked out by a worktree cannot be checked out elsewhere. If merging directly is
+necessary, do not attempt `git checkout worktree-<name>` — it will fail with
+`fatal: '<branch>' is already used by worktree`. Merge the branch without checking it out.
+
+### Cleanup
+
+The merge script handles cleanup automatically on a successful merge. For periodic housekeeping or
+abandoned worktrees, review what is active:
+
+```text
+git worktree list
+```
+
+Before removing a branch manually, verify it has been fully merged:
+
+```text
+git log --oneline <target-branch>..worktree-<name>
+```
+
+If no commits are shown, the branch can be safely removed.
+
 ### Token discipline
 
-The primary token benefit of worktrees is keeping each session context small and scoped. One task
-per worktree. End and replace sessions rather than extending them indefinitely. A scoped session
-that finishes cleanly costs far fewer tokens than a long-running session that accumulates context
-drift.
+Keep each session scoped to one task. End and replace sessions rather than extending them
+indefinitely. A scoped session that finishes cleanly costs far fewer tokens than a long-running
+session that accumulates context drift.

--- a/scripts/worktree-merge.sh
+++ b/scripts/worktree-merge.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Merge a Claude Code worktree branch into a target branch and clean up.
+# Usage: scripts/worktree-merge.sh <name> <target-branch> [commit-message]
+#
+# The deterministic git mechanics live here so they run with no token cost
+# and no improvisation. Judgment steps (commit message, conflict resolution)
+# are handled by the caller — see .claude/commands/merge-worktree.md.
+set -euo pipefail
+
+NAME="${1:?Usage: worktree-merge.sh <name> <target-branch> [commit-message]}"
+TARGET="${2:?Usage: worktree-merge.sh <name> <target-branch> [commit-message]}"
+MSG="${3:-}"
+
+WT=".claude/worktrees/${NAME}"
+BRANCH="worktree-${NAME}"
+
+if [ ! -d "$WT" ]; then
+  echo "error: worktree not found at $WT" >&2
+  exit 1
+fi
+
+# Refuse to proceed if the main working tree is dirty — switching branches
+# under uncommitted changes leads to a confusing state.
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: main working tree has uncommitted changes. Commit or stash them first." >&2
+  exit 1
+fi
+
+# 1. Commit pending changes inside the worktree, if any.
+if [ -n "$(git -C "$WT" status --porcelain)" ]; then
+  if [ -z "$MSG" ]; then
+    echo "error: uncommitted changes in $WT but no commit message given." >&2
+    echo "       re-run with a message as the third argument." >&2
+    exit 1
+  fi
+  git -C "$WT" add -A
+  git -C "$WT" commit -m "$MSG"
+  echo "committed changes on $BRANCH"
+else
+  echo "no uncommitted changes in $WT"
+fi
+
+# 2. Merge into the target branch. A merge conflict aborts the script here
+#    (set -e), so cleanup below is skipped and nothing is removed while in a
+#    conflicted state.
+git checkout "$TARGET"
+git merge "$BRANCH"
+
+# 3. Clean up — only reached on a clean merge.
+git worktree remove "$WT"
+git branch -d "$BRANCH"        # -d refuses to delete an unmerged branch (safe guard)
+git worktree prune
+
+echo "done: merged $BRANCH into $TARGET and removed the worktree"


### PR DESCRIPTION
## Summary

Improves the dev environment experience through three key changes: migrates static Expo config to dynamic `app.config.ts` for environment-specific naming, installs and configures `eslint-plugin-simple-import-sort` with proper import grouping and merging, and adds `EXPO_NO_DEPENDENCY_VALIDATION=1` to startup scripts to fix Expo Go compatibility issues.

## Changes

- **Expo config**: Migrated `app.json` → `app.config.ts` with dynamic naming (dev vs. prod) and env-specific overrides
- **Import sorting**: Added `eslint-plugin-simple-import-sort` with configured import groups; applied sorting across all app files
- **Import deduplication**: Added `no-duplicate-imports` ESLint rule to prevent future split imports from the same source
- **Startup scripts**: Added `EXPO_NO_DEPENDENCY_VALIDATION=1` env var to fix Expo Go startup issues
- **Dev tools**: Updated `.vscode/extensions.json` and `.vscode/settings.json` with ESLint and Prettier configuration for import sorting and formatting
- **Documentation**: Expanded `git-workflow.md` with comprehensive worktree merge workflow including autonomous session guidance and conflict resolution; updated `merge-worktree.md` command to enforce hard stop on conflicts; updated `mobile-project-structure` SKILL.md to reflect new Expo config pattern

## Related

Closes #62

## Documentation Updates

Updated three reference documents:
- `docs/process/git-workflow.md` — expanded worktree merging section with autonomous workflow, sequential merge strategy, and detailed conflict handling
- `.claude/commands/merge-worktree.md` — enforced hard stop on merge conflicts to prevent automatic resolution attempts
- `.claude/skills/mobile-project-structure/SKILL.md` — documented `app.config.ts` with env-specific overrides as the canonical Expo config approach

## ADR Requirement

Not required.

## Definition of Done

- [x] Code changes tested (linting, import sorting applied consistently)
- [x] All documentation updated to reflect changes and new workflows
- [x] No security or performance concerns introduced
- [x] Ready for review