### PR TITLE
feat(frontend): Reorganize navigation and implement profile-completion banner

### DIFF
--- a/app/src/features/discover/index.ts
+++ b/app/src/features/discover/index.ts
@@ -1,0 +1,1 @@
+export { DiscoverScreen } from "./screens/DiscoverScreen";

--- a/app/src/features/discover/screens/DiscoverScreen.tsx
+++ b/app/src/features/discover/screens/DiscoverScreen.tsx
@@ -1,0 +1,45 @@
+import { StyleSheet, View } from "react-native";
+
+import { AppText, Screen } from "@/components/ui";
+import { ProfileCompletionBanner } from "@/features/profile";
+import { spacing } from "@/styles/tokens";
+
+/**
+ * New members land here straight after fast signup. They can browse, but the feed is
+ * empty for now — plans, hosting, and matching arrive in later issues.
+ *
+ * The completion banner is a connected component sharing state via ProfileCompletionProvider, so a
+ * dismiss persists as the member moves between screens. The screen owns its safe area through
+ * `Screen`; the banner sits in the already-safe content area.
+ */
+export function DiscoverScreen() {
+  return (
+    <Screen>
+      <ProfileCompletionBanner />
+
+      <View style={styles.header}>
+        <AppText variant="headline">Discover</AppText>
+      </View>
+
+      <View style={styles.body}>
+        <AppText variant="subhead" style={styles.empty}>
+          Plans near you will show up here soon.
+        </AppText>
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    paddingTop: spacing.lg,
+  },
+  body: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  empty: {
+    textAlign: "center",
+  },
+});

--- a/app/src/features/onboarding/screens/PhoneEntryScreen.tsx
+++ b/app/src/features/onboarding/screens/PhoneEntryScreen.tsx
@@ -4,13 +4,13 @@ import { StyleSheet, View } from "react-native";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 import { AppText, Button, Screen, Wordmark } from "@/components/ui";
-import type { RootStackParamList } from "@/navigation/types";
+import type { OnboardingStackParamList } from "@/navigation/types";
 import { colors, spacing } from "@/styles/tokens";
 
 import { PhoneNumberInput } from "../components/PhoneNumberInput";
 import { TermsFootnote } from "../components/TermsFootnote";
 
-type Props = NativeStackScreenProps<RootStackParamList, "PhoneEntry">;
+type Props = NativeStackScreenProps<OnboardingStackParamList, "PhoneEntry">;
 
 const DEFAULT_COUNTRY = "🇺🇸 +1";
 const MIN_DIGITS = 7;

--- a/app/src/features/onboarding/screens/ProfileSetupScreen.tsx
+++ b/app/src/features/onboarding/screens/ProfileSetupScreen.tsx
@@ -1,12 +1,20 @@
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 
+import type {
+  NativeStackNavigationProp,
+  NativeStackScreenProps,
+} from "@react-navigation/native-stack";
+
 import { AppText, Button, Screen, TextField } from "@/components/ui";
+import type { OnboardingStackParamList, RootStackParamList } from "@/navigation/types";
 import { spacing } from "@/styles/tokens";
 
 import { DateOfBirthField } from "../components/DateOfBirthField";
 import { type GenderIdentity, GenderSelect } from "../components/GenderSelect";
 import { MIN_AGE, validateDob } from "../lib/dob";
+
+type Props = NativeStackScreenProps<OnboardingStackParamList, "ProfileSetup">;
 
 const MAX_NAME_LENGTH = 50;
 
@@ -16,7 +24,7 @@ const MAX_NAME_LENGTH = 50;
  * via the profile completion flow. The screen owns its form state and derives validity during
  * render; account creation is the parent's job once the backend exists.
  */
-export function ProfileSetupScreen() {
+export function ProfileSetupScreen({ navigation }: Props) {
   const [firstName, setFirstName] = useState("");
   const [dateOfBirth, setDateOfBirth] = useState("");
   const [gender, setGender] = useState<GenderIdentity | null>(null);
@@ -32,7 +40,11 @@ export function ProfileSetupScreen() {
   const handleSubmit = () => {
     if (!canSubmit) return;
     // TODO: create the account with { firstName, dateOfBirth, gender } plus the verified
-    // phone number and route into the app once the backend and home screen exist.
+    // phone number once the backend exists. Replacing the root Onboarding route with Main
+    // discards the whole onboarding stack so the member can't swipe back into signup.
+    navigation
+      .getParent<NativeStackNavigationProp<RootStackParamList>>()
+      ?.replace("Main", { screen: "Discover" });
   };
 
   return (

--- a/app/src/features/onboarding/screens/SplashScreen.tsx
+++ b/app/src/features/onboarding/screens/SplashScreen.tsx
@@ -4,10 +4,10 @@ import { Animated, StyleSheet } from "react-native";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 import { Screen, Wordmark } from "@/components/ui";
-import type { RootStackParamList } from "@/navigation/types";
+import type { OnboardingStackParamList } from "@/navigation/types";
 import { animation } from "@/styles/tokens";
 
-type Props = NativeStackScreenProps<RootStackParamList, "Splash">;
+type Props = NativeStackScreenProps<OnboardingStackParamList, "Splash">;
 
 /**
  * The brand moment. The wordmark fades and scales in while the app finishes booting, then

--- a/app/src/features/onboarding/screens/VerifyScreen.tsx
+++ b/app/src/features/onboarding/screens/VerifyScreen.tsx
@@ -4,12 +4,12 @@ import { Pressable, StyleSheet, Text, View } from "react-native";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 import { AppText, Button, Screen } from "@/components/ui";
-import type { RootStackParamList } from "@/navigation/types";
+import type { OnboardingStackParamList } from "@/navigation/types";
 import { colors, fontFamily, fontSize, spacing } from "@/styles/tokens";
 
 import { CodeInput } from "../components/CodeInput";
 
-type Props = NativeStackScreenProps<RootStackParamList, "Verify">;
+type Props = NativeStackScreenProps<OnboardingStackParamList, "Verify">;
 
 const CODE_LENGTH = 6;
 

--- a/app/src/features/profile/components/ProfileCompletionBanner.tsx
+++ b/app/src/features/profile/components/ProfileCompletionBanner.tsx
@@ -1,0 +1,16 @@
+import { useProfileCompletion } from "../providers/ProfileCompletionProvider";
+
+import { ProfileProgressBanner } from "./ProfileProgressBanner";
+
+/**
+ * Connected completion banner. Reads shared completion state and renders the nudge when there's
+ * something left to do. Drop it in as a main-app screen's first child inside `<Screen>`; the screen
+ * owns the safe area, and dismiss state is shared via the provider so it persists across screens.
+ */
+export function ProfileCompletionBanner() {
+  const { progress, isBannerVisible, dismissBanner } = useProfileCompletion();
+
+  if (!isBannerVisible) return null;
+
+  return <ProfileProgressBanner progress={progress} onDismiss={dismissBanner} />;
+}

--- a/app/src/features/profile/components/ProfileProgressBanner.tsx
+++ b/app/src/features/profile/components/ProfileProgressBanner.tsx
@@ -1,0 +1,119 @@
+import { Pressable, StyleSheet, View } from "react-native";
+
+import { AppText } from "@/components/ui";
+import { colors, fontFamily, fontSize, lineHeight, radii, spacing } from "@/styles/tokens";
+
+import type { ProfileProgress } from "../lib/profileProgress";
+
+/** The thin progress track is purely decorative chrome, so its height stays local. */
+const TRACK_HEIGHT = 6;
+
+type Props = {
+  progress: ProfileProgress;
+  onDismiss: () => void;
+};
+
+/**
+ * A warm, non-blocking nudge toward finishing the minimum profile. It matches the app
+ * background, sits at the top of the screen, and never gates browsing — the member can
+ * dismiss it. Presentational only: it renders the progress it is handed and reports a
+ * dismiss; deciding whether to show it and what "done" means lives with the screen.
+ */
+export function ProfileProgressBanner({ progress, onDismiss }: Props) {
+  const { ratio, completed, total, nextStep } = progress;
+  const message = nextStep?.nudge ?? "Your profile is all set.";
+
+  return (
+    <View style={styles.banner}>
+      <View style={styles.row}>
+        <View style={styles.copy}>
+          <AppText variant="label">Complete your profile</AppText>
+          <AppText variant="subhead" style={styles.message}>
+            {message}
+          </AppText>
+        </View>
+
+        <Pressable
+          onPress={onDismiss}
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss"
+          hitSlop={spacing.sm}
+          style={styles.dismiss}
+        >
+          <AppText style={styles.dismissGlyph}>×</AppText>
+        </Pressable>
+      </View>
+
+      <View style={styles.progressRow}>
+        <View
+          style={styles.track}
+          accessibilityRole="progressbar"
+          accessibilityValue={{ min: 0, max: total, now: completed }}
+        >
+          <View style={[styles.fill, { width: `${Math.round(ratio * 100)}%` }]} />
+        </View>
+        <AppText variant="subhead" style={styles.count}>
+          {completed} of {total}
+        </AppText>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    paddingVertical: spacing.md,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+    backgroundColor: colors.surface,
+    gap: spacing.sm,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: spacing.sm,
+  },
+  copy: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  message: {
+    fontSize: fontSize.caption,
+    lineHeight: lineHeight.caption,
+  },
+  dismiss: {
+    flexShrink: 0,
+    width: spacing.lg,
+    height: spacing.lg,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dismissGlyph: {
+    fontFamily: fontFamily.bold,
+    fontSize: fontSize.h2,
+    lineHeight: fontSize.h2,
+    color: colors.muted,
+  },
+  progressRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  track: {
+    flex: 1,
+    height: TRACK_HEIGHT,
+    borderRadius: radii.pill,
+    backgroundColor: colors.tealSoft,
+    overflow: "hidden",
+  },
+  fill: {
+    height: "100%",
+    borderRadius: radii.pill,
+    backgroundColor: colors.tealPrimary,
+  },
+  count: {
+    flexShrink: 0,
+    fontSize: fontSize.caption,
+    lineHeight: lineHeight.caption,
+  },
+});

--- a/app/src/features/profile/index.ts
+++ b/app/src/features/profile/index.ts
@@ -1,0 +1,5 @@
+export { ProfileCompletionBanner } from "./components/ProfileCompletionBanner";
+export {
+  ProfileCompletionProvider,
+  useProfileCompletion,
+} from "./providers/ProfileCompletionProvider";

--- a/app/src/features/profile/lib/profileProgress.ts
+++ b/app/src/features/profile/lib/profileProgress.ts
@@ -1,0 +1,52 @@
+/**
+ * The self-serve profile work a new member must finish before they can take action
+ * (join a plan, host one, or enter the matching pool). Team approval is also required,
+ * but it is a separate wait-state concern the member cannot act on, so it is intentionally
+ * not part of this progress model — the completion banner only nudges what the user can do.
+ */
+export type ProfileCompletion = {
+  hasPhoto: boolean;
+  hasPrompt: boolean;
+};
+
+export type ProfileStep = {
+  key: keyof ProfileCompletion;
+  /** Warm, encouraging nudge shown while this is the next thing left to do. */
+  nudge: string;
+  done: boolean;
+};
+
+const STEP_NUDGES: { key: keyof ProfileCompletion; nudge: string }[] = [
+  { key: "hasPhoto", nudge: "Add a photo to start joining plans." },
+  { key: "hasPrompt", nudge: "Answer a prompt so hosts get to know you." },
+];
+
+export type ProfileProgress = {
+  steps: ProfileStep[];
+  completed: number;
+  total: number;
+  /** 0–1 fraction for the progress bar fill. */
+  ratio: number;
+  isComplete: boolean;
+  /** The next unfinished step, or null once the profile is complete. */
+  nextStep: ProfileStep | null;
+};
+
+export function getProfileProgress(completion: ProfileCompletion): ProfileProgress {
+  const steps: ProfileStep[] = STEP_NUDGES.map(({ key, nudge }) => ({
+    key,
+    nudge,
+    done: completion[key],
+  }));
+  const completed = steps.filter((step) => step.done).length;
+  const total = steps.length;
+
+  return {
+    steps,
+    completed,
+    total,
+    ratio: total === 0 ? 1 : completed / total,
+    isComplete: completed === total,
+    nextStep: steps.find((step) => !step.done) ?? null,
+  };
+}

--- a/app/src/features/profile/providers/ProfileCompletionProvider.tsx
+++ b/app/src/features/profile/providers/ProfileCompletionProvider.tsx
@@ -1,0 +1,51 @@
+import { createContext, type PropsWithChildren, useContext, useMemo, useState } from "react";
+
+import {
+  getProfileProgress,
+  type ProfileCompletion,
+  type ProfileProgress,
+} from "../lib/profileProgress";
+
+// Hardcoded empty until the profile/account service exists. Owned here so completion can later be
+// fed from that service in one place and shared across every main-app screen.
+const INITIAL_COMPLETION: ProfileCompletion = { hasPhoto: false, hasPrompt: false };
+
+type ProfileCompletionValue = {
+  progress: ProfileProgress;
+  /** Whether the completion banner should show: there's work left and it hasn't been dismissed. */
+  isBannerVisible: boolean;
+  dismissBanner: () => void;
+};
+
+const ProfileCompletionContext = createContext<ProfileCompletionValue | null>(null);
+
+/**
+ * Owns profile-completion state for the signed-in app. Mounted once around the main navigator so
+ * completion and the banner's dismissed state are shared across every screen — a dismiss on one
+ * screen sticks as the member moves between screens, rather than resetting per screen.
+ */
+export function ProfileCompletionProvider({ children }: PropsWithChildren) {
+  const [completion] = useState<ProfileCompletion>(INITIAL_COMPLETION);
+  const [dismissed, setDismissed] = useState(false);
+
+  const value = useMemo<ProfileCompletionValue>(() => {
+    const progress = getProfileProgress(completion);
+    return {
+      progress,
+      isBannerVisible: !progress.isComplete && !dismissed,
+      dismissBanner: () => setDismissed(true),
+    };
+  }, [completion, dismissed]);
+
+  return (
+    <ProfileCompletionContext.Provider value={value}>{children}</ProfileCompletionContext.Provider>
+  );
+}
+
+export function useProfileCompletion(): ProfileCompletionValue {
+  const value = useContext(ProfileCompletionContext);
+  if (!value) {
+    throw new Error("useProfileCompletion must be used within a ProfileCompletionProvider");
+  }
+  return value;
+}

--- a/app/src/navigation/DevBar.tsx
+++ b/app/src/navigation/DevBar.tsx
@@ -18,13 +18,32 @@ export function DevBar({ navigationRef }: Props) {
   };
 
   const buttons = [
-    { label: "Splash", onPress: () => go(() => navigationRef.navigate("Splash")) },
-    { label: "Phone", onPress: () => go(() => navigationRef.navigate("PhoneEntry")) },
+    {
+      label: "Splash",
+      onPress: () => go(() => navigationRef.navigate("Onboarding", { screen: "Splash" })),
+    },
+    {
+      label: "Phone",
+      onPress: () => go(() => navigationRef.navigate("Onboarding", { screen: "PhoneEntry" })),
+    },
     {
       label: "Verify",
-      onPress: () => go(() => navigationRef.navigate("Verify", { phoneNumber: "+15551234567" })),
+      onPress: () =>
+        go(() =>
+          navigationRef.navigate("Onboarding", {
+            screen: "Verify",
+            params: { phoneNumber: "+15551234567" },
+          }),
+        ),
     },
-    { label: "Profile", onPress: () => go(() => navigationRef.navigate("ProfileSetup")) },
+    {
+      label: "Profile",
+      onPress: () => go(() => navigationRef.navigate("Onboarding", { screen: "ProfileSetup" })),
+    },
+    {
+      label: "Discover",
+      onPress: () => go(() => navigationRef.navigate("Main", { screen: "Discover" })),
+    },
   ];
 
   return (

--- a/app/src/navigation/MainNavigator.tsx
+++ b/app/src/navigation/MainNavigator.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+
+import { DiscoverScreen } from "@/features/discover";
+import { ProfileCompletionProvider } from "@/features/profile";
+
+import type { MainStackParamList } from "./types";
+
+const Stack = createNativeStackNavigator<MainStackParamList>();
+
+/**
+ * The signed-in app. A native stack for now (Discover only); it becomes a tab navigator once
+ * Chat/Profile arrive, with no change here. `ProfileCompletionProvider` wraps the navigator so the
+ * profile-completion banner's state is shared across every main-app screen — screens render the
+ * banner themselves and own their own safe area; this stays pure route wiring plus shared state.
+ */
+export function MainNavigator() {
+  return (
+    <ProfileCompletionProvider>
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="Discover" component={DiscoverScreen} />
+      </Stack.Navigator>
+    </ProfileCompletionProvider>
+  );
+}

--- a/app/src/navigation/OnboardingNavigator.tsx
+++ b/app/src/navigation/OnboardingNavigator.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+
+import {
+  PhoneEntryScreen,
+  ProfileSetupScreen,
+  SplashScreen,
+  VerifyScreen,
+} from "@/features/onboarding";
+
+import type { OnboardingStackParamList } from "./types";
+
+const Stack = createNativeStackNavigator<OnboardingStackParamList>();
+
+/**
+ * The pre-account flow: Splash → Phone Entry → Verify → Profile Setup. Headers are hidden so each
+ * screen owns its own chrome. Completing setup resets the root to the Main app, which discards this
+ * whole stack so members can't swipe back into signup.
+ */
+export function OnboardingNavigator() {
+  return (
+    <Stack.Navigator initialRouteName="Splash" screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="Splash" component={SplashScreen} />
+      <Stack.Screen name="PhoneEntry" component={PhoneEntryScreen} />
+      <Stack.Screen name="Verify" component={VerifyScreen} />
+      <Stack.Screen name="ProfileSetup" component={ProfileSetupScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/app/src/navigation/RootNavigator.tsx
+++ b/app/src/navigation/RootNavigator.tsx
@@ -2,28 +2,22 @@ import React from "react";
 
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 
-import {
-  PhoneEntryScreen,
-  ProfileSetupScreen,
-  SplashScreen,
-  VerifyScreen,
-} from "@/features/onboarding";
-
+import { MainNavigator } from "./MainNavigator";
+import { OnboardingNavigator } from "./OnboardingNavigator";
 import type { RootStackParamList } from "./types";
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 /**
- * The onboarding entry stack: Splash → Phone Entry → Verify → Profile Setup. Headers are hidden so each
- * screen owns its own chrome. This navigator only wires routes to screens.
+ * The top-level split between the pre-account onboarding flow and the signed-in app. Headers are
+ * hidden; each nested navigator owns its own chrome. Onboarding replaces itself with Main on
+ * completion, so the onboarding stack does not linger on the back stack.
  */
 export function RootNavigator() {
   return (
-    <Stack.Navigator initialRouteName="Splash" screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="Splash" component={SplashScreen} />
-      <Stack.Screen name="PhoneEntry" component={PhoneEntryScreen} />
-      <Stack.Screen name="Verify" component={VerifyScreen} />
-      <Stack.Screen name="ProfileSetup" component={ProfileSetupScreen} />
+    <Stack.Navigator initialRouteName="Onboarding" screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="Onboarding" component={OnboardingNavigator} />
+      <Stack.Screen name="Main" component={MainNavigator} />
     </Stack.Navigator>
   );
 }

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -1,7 +1,24 @@
-export type RootStackParamList = {
+import type { NavigatorScreenParams } from "@react-navigation/native";
+
+/** The pre-account flow. Discarded from the stack once an account exists. */
+export type OnboardingStackParamList = {
   Splash: undefined;
   PhoneEntry: undefined;
   Verify: { phoneNumber: string };
   ProfileSetup: undefined;
-  DevMenu: undefined;
+};
+
+/**
+ * The signed-in app. A native stack for now (Discover only); it becomes a tab navigator
+ * once Chat/Profile arrive. The profile-completion banner lives in the Main shell above
+ * this navigator, not in any single screen here.
+ */
+export type MainStackParamList = {
+  Discover: undefined;
+};
+
+/** Top-level split: the onboarding flow versus the signed-in app. */
+export type RootStackParamList = {
+  Onboarding: NavigatorScreenParams<OnboardingStackParamList>;
+  Main: NavigatorScreenParams<MainStackParamList>;
 };


### PR DESCRIPTION
## Summary

Split RootNavigator into Onboarding (pre-account signup flow) and Main (signed-in app). The profile-completion banner is now owned by the Main shell via `ProfileCompletionProvider`, so completion state and dismiss behavior persist across screens. `Screen` primitive owns safe-area insets uniformly. Onboarding and Main navigators are now clearly separated with proper route param types for each.

## Changes

- New `OnboardingNavigator` — wires Splash → PhoneEntry → Verify → ProfileSetup
- New `MainNavigator` — provides `ProfileCompletionProvider` wrapping the inner route navigator
- New `ProfileCompletionProvider` — owns completion + dismissed state, mounted once at Main
- New `ProfileCompletionBanner` — connected component reading provider, renders the nudge or null
- `RootNavigator` — simplified to route between Onboarding and Main
- `DiscoverScreen` — renders `<ProfileCompletionBanner />` as first child inside `<Screen>`
- Updated param types: `RootStackParamList` splits into `OnboardingStackParamList` + `MainStackParamList` via `NavigatorScreenParams`
- Onboarding screens retyped to `OnboardingStackParamList`
- `ProfileSetupScreen` finishes by resetting root to Main via `navigation.getParent().replace("Main", …)`
- `DevBar` — buttons use nested navigation (e.g., `navigate("Onboarding", { screen: … })`)

## Related

Closes #66

## Documentation Updates

Not applicable

## ADR Requirement

Not required

## Definition of Done

- ✅ Navigator split is clean: Onboarding and Main are separate stacks with clear ownership
- ✅ Banner state persists across screens via provider
- ✅ Screen primitive owns all safe-area insets uniformly
- ✅ TypeScript and ESLint pass
- ✅ Code formatted with Prettier