### PR TITLE
feat(frontend): Implement bottom navigation bar

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,7 +25,13 @@
       "Bash(gh api*)",
       "Bash(npm run lint:md*)",
       "Bash(npm run format:md*)",
-      "Bash(npx markdownlint-cli2 *)"
+      "Bash(npx markdownlint-cli2 *)",
+      "Bash(npx tsc *)",
+      "Bash(npx eslint *)",
+      "Bash(npx prettier *)",
+      "Bash(echo \"=== TSC: $? ===\")",
+      "Bash(echo \"=== ESLINT: $? ===\")",
+      "Bash(echo \"EXIT: $?\")"
     ],
     "deny": [
       "Bash(git rebase*)",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo-google-fonts/nunito": "^0.4.2",
+        "@expo/vector-icons": "^15.1.1",
         "@react-navigation/bottom-tabs": "^7.16.2",
         "@react-navigation/native": "^7.2.5",
         "@react-navigation/native-stack": "^7.16.0",
@@ -2493,6 +2494,17 @@
       "resolved": "https://registry.npmjs.org/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
       "license": "MIT"
+    },
+    "node_modules/@expo/vector-icons": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
+      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/@expo/ws-tunnel": {
       "version": "1.0.6",
@@ -6087,17 +6099,6 @@
         "expo": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo/node_modules/@expo/vector-icons": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
-      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo-font": ">=14.0.4",
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo/node_modules/accepts": {

--- a/app/package.json
+++ b/app/package.json
@@ -4,6 +4,7 @@
   "main": "index.ts",
   "dependencies": {
     "@expo-google-fonts/nunito": "^0.4.2",
+    "@expo/vector-icons": "^15.1.1",
     "@react-navigation/bottom-tabs": "^7.16.2",
     "@react-navigation/native": "^7.2.5",
     "@react-navigation/native-stack": "^7.16.0",

--- a/app/src/features/explore/index.ts
+++ b/app/src/features/explore/index.ts
@@ -1,0 +1,1 @@
+export { ExploreScreen } from "./screens/ExploreScreen";

--- a/app/src/features/explore/screens/ExploreScreen.tsx
+++ b/app/src/features/explore/screens/ExploreScreen.tsx
@@ -1,0 +1,39 @@
+import { StyleSheet, View } from "react-native";
+
+import { AppText, Screen } from "@/components/ui";
+import { spacing } from "@/styles/tokens";
+
+/**
+ * Browse plans by neighbourhood, time, and type. The list, filters, and "tonight" sections
+ * from the prototype arrive in later issues — for now this is an empty placeholder so the
+ * bottom-nav tab has a destination. The screen owns its safe area through `Screen`.
+ */
+export function ExploreScreen() {
+  return (
+    <Screen>
+      <View style={styles.header}>
+        <AppText variant="headline">Explore</AppText>
+      </View>
+
+      <View style={styles.body}>
+        <AppText variant="subhead" style={styles.empty}>
+          Plans to explore will show up here soon.
+        </AppText>
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    paddingTop: spacing.lg,
+  },
+  body: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  empty: {
+    textAlign: "center",
+  },
+});

--- a/app/src/features/messages/index.ts
+++ b/app/src/features/messages/index.ts
@@ -1,0 +1,1 @@
+export { MessagesScreen } from "./screens/MessagesScreen";

--- a/app/src/features/messages/screens/MessagesScreen.tsx
+++ b/app/src/features/messages/screens/MessagesScreen.tsx
@@ -1,0 +1,39 @@
+import { StyleSheet, View } from "react-native";
+
+import { AppText, Screen } from "@/components/ui";
+import { spacing } from "@/styles/tokens";
+
+/**
+ * Conversations with people from shared plans. Threads, tabs, and unread state from the
+ * prototype arrive once matching and messaging land — for now this is an empty placeholder
+ * so the bottom-nav tab has a destination. The screen owns its safe area through `Screen`.
+ */
+export function MessagesScreen() {
+  return (
+    <Screen>
+      <View style={styles.header}>
+        <AppText variant="headline">Messages</AppText>
+      </View>
+
+      <View style={styles.body}>
+        <AppText variant="subhead" style={styles.empty}>
+          Your conversations will appear here soon.
+        </AppText>
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    paddingTop: spacing.lg,
+  },
+  body: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  empty: {
+    textAlign: "center",
+  },
+});

--- a/app/src/features/postPlan/index.ts
+++ b/app/src/features/postPlan/index.ts
@@ -1,0 +1,1 @@
+export { PostPlanScreen } from "./screens/PostPlanScreen";

--- a/app/src/features/postPlan/screens/PostPlanScreen.tsx
+++ b/app/src/features/postPlan/screens/PostPlanScreen.tsx
@@ -1,0 +1,39 @@
+import { StyleSheet, View } from "react-native";
+
+import { AppText, Screen } from "@/components/ui";
+import { spacing } from "@/styles/tokens";
+
+/**
+ * Reached from the centre action of the bottom nav. The type selector and plan form from the
+ * prototype arrive in a later issue — for now this is an empty placeholder so the action has a
+ * destination. The screen owns its safe area through `Screen`.
+ */
+export function PostPlanScreen() {
+  return (
+    <Screen>
+      <View style={styles.header}>
+        <AppText variant="headline">Post a plan</AppText>
+      </View>
+
+      <View style={styles.body}>
+        <AppText variant="subhead" style={styles.empty}>
+          Sharing a plan will live here soon.
+        </AppText>
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    paddingTop: spacing.lg,
+  },
+  body: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  empty: {
+    textAlign: "center",
+  },
+});

--- a/app/src/features/profile/index.ts
+++ b/app/src/features/profile/index.ts
@@ -3,3 +3,4 @@ export {
   ProfileCompletionProvider,
   useProfileCompletion,
 } from "./providers/ProfileCompletionProvider";
+export { ProfileScreen } from "./screens/ProfileScreen";

--- a/app/src/features/profile/screens/ProfileScreen.tsx
+++ b/app/src/features/profile/screens/ProfileScreen.tsx
@@ -1,0 +1,39 @@
+import { StyleSheet, View } from "react-native";
+
+import { AppText, Screen } from "@/components/ui";
+import { spacing } from "@/styles/tokens";
+
+/**
+ * The member's own profile. Editing, prompts, and photos arrive in later issues — for now this
+ * is an empty placeholder so the bottom-nav tab has a destination. The screen owns its safe area
+ * through `Screen`.
+ */
+export function ProfileScreen() {
+  return (
+    <Screen>
+      <View style={styles.header}>
+        <AppText variant="headline">Profile</AppText>
+      </View>
+
+      <View style={styles.body}>
+        <AppText variant="subhead" style={styles.empty}>
+          Your profile will live here soon.
+        </AppText>
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    paddingTop: spacing.lg,
+  },
+  body: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  empty: {
+    textAlign: "center",
+  },
+});

--- a/app/src/navigation/MainNavigator.tsx
+++ b/app/src/navigation/MainNavigator.tsx
@@ -1,26 +1,40 @@
 import React from "react";
 
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 
 import { DiscoverScreen } from "@/features/discover";
-import { ProfileCompletionProvider } from "@/features/profile";
+import { ExploreScreen } from "@/features/explore";
+import { MessagesScreen } from "@/features/messages";
+import { PostPlanScreen } from "@/features/postPlan";
+import { ProfileCompletionProvider, ProfileScreen } from "@/features/profile";
 
-import type { MainStackParamList } from "./types";
+import { MainTabBar } from "./MainTabBar";
+import type { MainTabParamList } from "./types";
 
-const Stack = createNativeStackNavigator<MainStackParamList>();
+const Tab = createBottomTabNavigator<MainTabParamList>();
 
 /**
- * The signed-in app. A native stack for now (Discover only); it becomes a tab navigator once
- * Chat/Profile arrive, with no change here. `ProfileCompletionProvider` wraps the navigator so the
- * profile-completion banner's state is shared across every main-app screen — screens render the
- * banner themselves and own their own safe area; this stays pure route wiring plus shared state.
+ * The signed-in app: a bottom-tab navigator with a custom tab bar (`MainTabBar`) modelled on the
+ * product prototype — Messages, Explore, the central Post-a-plan FAB, Discover, and Profile, with
+ * Discover as the landing tab. Screens are registered left-to-right so `PostPlan` falls in the
+ * centre slot the FAB occupies. `ProfileCompletionProvider` wraps the navigator so the
+ * profile-completion banner's state is shared across tabs; screens render the banner themselves and
+ * own their own safe area, keeping this pure route wiring plus shared state.
  */
 export function MainNavigator() {
   return (
     <ProfileCompletionProvider>
-      <Stack.Navigator screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="Discover" component={DiscoverScreen} />
-      </Stack.Navigator>
+      <Tab.Navigator
+        initialRouteName="Discover"
+        screenOptions={{ headerShown: false }}
+        tabBar={(props) => <MainTabBar {...props} />}
+      >
+        <Tab.Screen name="Messages" component={MessagesScreen} />
+        <Tab.Screen name="Explore" component={ExploreScreen} />
+        <Tab.Screen name="PostPlan" component={PostPlanScreen} />
+        <Tab.Screen name="Discover" component={DiscoverScreen} />
+        <Tab.Screen name="Profile" component={ProfileScreen} />
+      </Tab.Navigator>
     </ProfileCompletionProvider>
   );
 }

--- a/app/src/navigation/MainTabBar.tsx
+++ b/app/src/navigation/MainTabBar.tsx
@@ -1,0 +1,150 @@
+import { Pressable, StyleSheet, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { Feather } from "@expo/vector-icons";
+
+import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { AppText } from "@/components/ui";
+import { colors, fontFamily, radii, shadows } from "@/styles/tokens";
+
+import type { MainTabParamList } from "./types";
+
+/**
+ * The signed-in app's bottom navigation, modelled on the product prototype: four labelled
+ * tabs with the central "Post a plan" action raised into a teal gradient FAB. It owns its own
+ * bottom safe-area inset because it is the chrome that sits against the home indicator — the
+ * tab bar owning its internal layout, not the navigator shell reaching into insets. Per-screen
+ * top/bottom insets remain with the `Screen` primitive.
+ */
+
+const BAR_HEIGHT = 60;
+const ICON_SIZE = 22;
+const LABEL_SIZE = 10;
+const FAB_SIZE = 44;
+const FAB_ICON_SIZE = 24;
+
+type FeatherName = React.ComponentProps<typeof Feather>["name"];
+
+const TAB_ICON: Record<Exclude<keyof MainTabParamList, "PostPlan">, FeatherName> = {
+  Messages: "message-circle",
+  Explore: "compass",
+  Discover: "layers",
+  Profile: "user",
+};
+
+const TAB_LABEL: Record<keyof MainTabParamList, string> = {
+  Messages: "Messages",
+  Explore: "Explore",
+  PostPlan: "Post a plan",
+  Discover: "Discover",
+  Profile: "Profile",
+};
+
+export function MainTabBar({ state, navigation }: BottomTabBarProps) {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View
+      style={[styles.bar, { height: BAR_HEIGHT + insets.bottom, paddingBottom: insets.bottom }]}
+    >
+      {state.routes.map((route, index) => {
+        const focused = state.index === index;
+        const label = TAB_LABEL[route.name as keyof MainTabParamList];
+
+        const onPress = () => {
+          const event = navigation.emit({
+            type: "tabPress",
+            target: route.key,
+            canPreventDefault: true,
+          });
+          if (!focused && !event.defaultPrevented) {
+            navigation.navigate(route.name);
+          }
+        };
+
+        if (route.name === "PostPlan") {
+          return (
+            <Pressable
+              key={route.key}
+              onPress={onPress}
+              accessibilityRole="button"
+              accessibilityLabel={label}
+              style={({ pressed }) => [styles.fabWrap, pressed && styles.fabPressed]}
+            >
+              <LinearGradient
+                colors={[colors.gradientStart, colors.gradientEnd]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+                style={[styles.fab, shadows.buttonTeal]}
+              >
+                <Feather name="plus" size={FAB_ICON_SIZE} color={colors.onTeal} />
+              </LinearGradient>
+            </Pressable>
+          );
+        }
+
+        const iconName = TAB_ICON[route.name as Exclude<keyof MainTabParamList, "PostPlan">];
+        const iconColor = focused ? colors.tealPrimary : colors.muted;
+
+        return (
+          <Pressable
+            key={route.key}
+            onPress={onPress}
+            accessibilityRole="button"
+            accessibilityState={{ selected: focused }}
+            accessibilityLabel={label}
+            style={styles.navBtn}
+          >
+            <Feather name={iconName} size={ICON_SIZE} color={iconColor} />
+            <AppText style={[styles.label, focused && styles.labelActive]}>{label}</AppText>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-around",
+    backgroundColor: colors.white,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.border,
+  },
+  navBtn: {
+    flex: 1,
+    height: BAR_HEIGHT,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 2,
+  },
+  label: {
+    fontFamily: fontFamily.semibold,
+    fontSize: LABEL_SIZE,
+    lineHeight: LABEL_SIZE + 3,
+    color: colors.muted,
+  },
+  labelActive: {
+    fontFamily: fontFamily.extrabold,
+    color: colors.tealPrimary,
+  },
+  fabWrap: {
+    flex: 1,
+    height: BAR_HEIGHT,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  fabPressed: {
+    transform: [{ scale: 0.94 }],
+  },
+  fab: {
+    width: FAB_SIZE,
+    height: FAB_SIZE,
+    borderRadius: radii.pill,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/app/src/navigation/types.ts
+++ b/app/src/navigation/types.ts
@@ -9,16 +9,20 @@ export type OnboardingStackParamList = {
 };
 
 /**
- * The signed-in app. A native stack for now (Discover only); it becomes a tab navigator
- * once Chat/Profile arrive. The profile-completion banner lives in the Main shell above
- * this navigator, not in any single screen here.
+ * The signed-in app: a bottom-tab navigator modelled on the product prototype. `PostPlan` is the
+ * centre action, raised into a FAB by the custom tab bar. The profile-completion banner is shared
+ * via a provider around this navigator and rendered by screens themselves, not threaded here.
  */
-export type MainStackParamList = {
+export type MainTabParamList = {
+  Messages: undefined;
+  Explore: undefined;
+  PostPlan: undefined;
   Discover: undefined;
+  Profile: undefined;
 };
 
 /** Top-level split: the onboarding flow versus the signed-in app. */
 export type RootStackParamList = {
   Onboarding: NavigatorScreenParams<OnboardingStackParamList>;
-  Main: NavigatorScreenParams<MainStackParamList>;
+  Main: NavigatorScreenParams<MainTabParamList>;
 };


### PR DESCRIPTION
## Summary

Converts the signed-in app from a single-screen Discover stack into a full bottom-tab navigator modelled on the product prototype. Adds four new empty placeholder screens (Messages, Explore, Profile) and the central Post-a-plan FAB action, landing on Discover.

## Changes

- **MainNavigator**: migrated from `createNativeStackNavigator` to `createBottomTabNavigator` with 5 routes
- **MainTabBar**: custom tab bar component with Feather icons (message-circle, compass, layers, user, plus) — active state via teal label + weight; FAB uses teal gradient + buttonTeal shadow token
- **New screens**: ExploreScreen, MessagesScreen, PostPlanScreen (empty placeholders); ProfileScreen added to complete the tab set
- **Routing**: Messages, Explore, PostPlan (FAB), Discover (landing), Profile — PostPlan in the centre slot per the prototype
- **Dependencies**: declared @expo/vector-icons@15.1.1 (already bundled in expo, now a direct dep)
- **Type safety**: replaced MainStackParamList with MainTabParamList; ProfileCompletionProvider still wraps the navigator

## Related

Closes #68

## Documentation Updates

Not applicable.

## ADR Requirement

Not applicable.

## Definition of Done

- ✓ Bottom nav matches prototype layout and styling
- ✓ All tabs navigate and persist state
- ✓ FAB action lands on PostPlanScreen
- ✓ Active state visuals (teal colour + weight) work correctly
- ✓ Safe-area handling: tab bar owns bottom inset; Screen owns top/bottom per-screen
- ✓ Typecheck and lint pass